### PR TITLE
Dockerize wetty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node
+MAINTAINER Nathan LeClaire <nathan@docker.com>
+
+ADD . /app
+WORKDIR /app
+RUN npm install
+RUN apt-get update
+RUN apt-get install -y vim
+RUN useradd -d /home/term -m -s /bin/bash term
+RUN echo 'term:term' | chpasswd
+
+EXPOSE 3000
+
+ENTRYPOINT ["node"]
+CMD ["app.js", "-p", "3000"]

--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ Issues
 ------
 
 Does not work on Firefox as hterm was written for ChromeOS. So works well on Chrome.
+
+Dockerized Version
+------------------
+
+This repo includes a Dockerfile you can use to run a Dockerized version of wetty.  You can run
+whatever you want!
+
+Just do:
+
+```
+docker run --name term -p 3000 -dt nathanleclaire/wetty
+```
+
+Visit the appropriate URL in your browser (`[localhost|$(boot2docker ip)]:PORT`).  
+The username is `term` and the password is `term`.


### PR DESCRIPTION
Submitting PR as requested!  This works at a basic level, but perhaps you can enlighten me- is there a way to configure wetty (or hit a certain endpoint) such that the user doesn't have to enter username and password (both `term` in this case)?
