### PR TITLE
Stabilise Wetty with regards to child process exits

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,9 @@ var fs = require('fs');
 var waitpid = require('waitpid');
 
 process.on('SIGCHLD', function(args){
+    console.error((new Date()) + " Got SIGCHLD: waiting for child process to terminate ... ")
     waitpid(-1);
+    console.error((new Date()) + " Child processed ended")
 });
 
 var opts = require('optimist')
@@ -129,11 +131,15 @@ wss.on('request', function(request) {
                     rows: 30
                 });
             }
+            console.log((new Date()) + " PID=" + term.pid + " STARTED on behalf of user=" + sshuser)
             term.on('data', function(data) {
                 conn.send(JSON.stringify({
                     data: data
                 }));
             });
+            term.on('exit', function(code) {
+                console.log((new Date()) + " PID=" + term.pid + " ENDED")
+            })
         }
         if (!data)
             return;

--- a/app.js
+++ b/app.js
@@ -7,12 +7,6 @@ var pty = require('pty.js');
 var fs = require('fs');
 var waitpid = require('waitpid');
 
-process.on('SIGCHLD', function(args){
-    console.error((new Date()) + " Got SIGCHLD: waiting for child process to terminate ... ")
-    waitpid(-1);
-    console.error((new Date()) + " Child processed ended")
-});
-
 var opts = require('optimist')
     .options({
         sslkey: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "express": "3.5.1",
     "websocket": "",
-    "pty.js": "",
+    "pty.js": "git+https://github.com/terryschen/pty.js",
     "optimist": "",
     "waitpid": ""
   },

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>wtf</title>
+    <title>Wetty - The WebTTY Terminal Emulator</title>
     <script src="/wetty/hterm_all.js"></script>
     <script src="/wetty/hterm.js"></script>
     <script src="/wetty/wetty.js"></script>

--- a/public/wetty/index.html
+++ b/public/wetty/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>wtf</title>
+    <title>Wetty - The WebTTY Terminal Emulator</title>
     <script src="/wetty/hterm_all.js"></script>
     <script src="/wetty/hterm.js"></script>
     <script src="/wetty/wetty.js"></script>


### PR DESCRIPTION
When using Wetty "out-of-the-box" it may hang because of wrong management of child processes.
Additionally the "WTF" title is not suitable for production use.

These "minimal fixes" allow Wetty to be rolled out to production safely.
