### PR TITLE
Hide scrollbar

### DIFF
--- a/public/wetty/wetty.js
+++ b/public/wetty/wetty.js
@@ -42,6 +42,7 @@ ws.onopen = function() {
         term.prefs_.set('ctrl-c-copy', true);
         term.prefs_.set('ctrl-v-paste', true);
         term.prefs_.set('use-default-window-copy', true);
+        term.prefs_.set('scrollbar-visible', false);
 
         term.runCommandClass(Wetty, document.location.hash.substr(1));
         ws.send(JSON.stringify({


### PR DESCRIPTION
I really prefer my terms without scrollbars. I'd rather this just be the default, but also understand if it gets into a bigger discussion around setting preferences.
