### PR TITLE
make it possible to define the target ssh host per url;

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,19 +117,13 @@ io.on('connection', function(socket){
     }
 
     var term;
-    if (process.getuid() === 0) {
-        term = pty.spawn('/bin/login', [], {
-            name: 'xterm-256color',
-            cols: 80,
-            rows: 30
-        });
-    } else {
-        term = pty.spawn('ssh', [sshuser + sshhost, '-p', sshport, '-o', 'PreferredAuthentications=' + sshauth], {
-            name: 'xterm-256color',
-            cols: 80,
-            rows: 30
-        });
-    }
+
+    term = pty.spawn('ssh', [sshuser + sshhost, '-p', sshport, '-o', 'PreferredAuthentications=' + sshauth], {
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 30
+    });
+
     console.log((new Date()) + " PID=" + term.pid + " STARTED on behalf of user=" + sshuser);
     term.on('data', function(data) {
         socket.emit('output', data);

--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ var opts = require('optimist')
         },
         whitelist: {
             demand: false,
-            description: 'whitelist of username/hosts, you can connect to'
+            description: 'whitelist of usernames/hosts you can connect to. Given as comma separated list of the form "^.*@localhost$,^user@hostname$".'
         }
     }).boolean('allow_discovery').argv;
 


### PR DESCRIPTION
Hello, 

I just added the possibility to select the target ssh host per url.

The URL can no be like this: http://localhost:3000/wetty/ssh/root/my-workstation

The old URL form (http://localhost:3000/wetty/ssh/root) is unaffected and is still usable.
