### PR TITLE
add a host option to listen on a specific ip

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,10 @@ var opts = require('optimist')
             demand: false,
             description: 'defaults to "password", you can use "publickey,password" instead'
         },
+	host: {
+	    demand: false,
+            description: 'wetty listen host'
+	},
         port: {
             demand: true,
             alias: 'p',
@@ -81,11 +85,11 @@ app.get('/wetty/ssh/:user', function(req, res) {
 app.use('/', express.static(path.join(__dirname, 'public')));
 
 if (runhttps) {
-    httpserv = https.createServer(opts.ssl, app).listen(opts.port, function() {
+    httpserv = https.createServer(opts.ssl, app).listen(opts.port, opts.host, function() {
         console.log('https on port ' + opts.port);
     });
 } else {
-    httpserv = http.createServer(app).listen(opts.port, function() {
+    httpserv = http.createServer(app).listen(opts.port, opts.host, function() {
         console.log('http on port ' + opts.port);
     });
 }


### PR DESCRIPTION
Tested `node app.js -p 3000 --host 127.0.0.01` and `node app.js -p 3000`.
Did not test with https.
