### PR TITLE
prevent accidental ctrl-w window closure

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,12 @@
 
 <body>
     <div id="terminal"></div>
+	<script type="application/javascript">
+window.addEventListener('beforeunload', function(e) {
+	e.returnValue = "Are you sure?";
+	return e.returnValue;
+});
+	</script>
 </body>
 
 </html>


### PR DESCRIPTION
Different browsers require different behavior for the `beforeunload` event handler, hence the odd `return e.returnValue`.
