### PR TITLE
Add module.exports

### DIFF
--- a/wetty.js
+++ b/wetty.js
@@ -89,3 +89,5 @@ export default function start(port, sshuser, sshhost, sshport, sshauth, sslopts)
   });
   return events;
 }
+
+module.exports = start;


### PR DESCRIPTION
Using the js export did not show the function when I used `require('wetty.js')` from another project (output was `{}`)
Adding this line at the end of wetty.js did the trick.