### PR TITLE
Add NPM start script to project.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
     "preferGlobal": "true",
     "bin": {
         "wetty": "./bin/wetty.js"
-    }
+    },
+    "scripts": { "start" : "node app.js -p 3000" }
 }


### PR DESCRIPTION
There are some automated deployment tools that require the presence of an NPM script.  This proposed change adds a start script with a default value for the port.