### PR TITLE
Change default socket.io timeout

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,8 +90,12 @@ if (runhttps) {
     });
 }
 
-var io = server(httpserv,{path: '/wetty/socket.io'});
-io.on('connection', function(socket){
+var io = server(httpserv, {
+    path: '/wetty/socket.io',
+    pingTimeout: 7000,
+    pingInterval: 3000
+});
+io.on('connection', function(socket) {
     var sshuser = '';
     var request = socket.request;
     console.log((new Date()) + ' Connection accepted.');


### PR DESCRIPTION
In some cases, the default timeout (60 seconds) might be too long. That could result the closing of connection in some proxy server configuration due to inactivity.

Documentation: [https://socket.io/docs/server-api/#](https://socket.io/docs/server-api/#)

Please consider merging this PR.