### PR TITLE
Prompt only if no user is known

### DIFF
--- a/wetty.mjs
+++ b/wetty.mjs
@@ -40,13 +40,14 @@ function getCommand(socket, sshuser, sshhost, sshport, sshauth) {
   const { request } = socket;
   const match = request.headers.referer.match('.+/ssh/.+$');
   const sshAddress = sshuser ? `${sshuser}@${sshhost}` : sshhost;
+  const sshPath = sshuser || match ? 'ssh' : path.join(__dirname, 'bin/ssh');
   const ssh = match ? `${match[0].split('/ssh/').pop()}@${sshhost}` : sshAddress;
 
   return [
     process.getuid() === 0 && sshhost === 'localhost'
       ? ['login', '-h', socket.client.conn.remoteAddress.split(':')[3]]
       : [
-        path.join(__dirname, 'bin/ssh'),
+        sshPath,
         ssh,
         '-p',
         sshport,


### PR DESCRIPTION
I was looking into alternative ways to collect username in an unobtrusive manner (e.g. no pop-ups, extra form elements etc.) to address #136 and have to agree that shell wrapper is a sensible trade off if zombies can be tolerated. My proposal then is to limit its use to cases when neither `SSHUSER` option is set nor `/ssh/<username>` address is used which shouldn't break any existing function but still allow proper process reaping.