### PR TITLE
Dockerfile slimming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN adduser -D -h /home/term -s /bin/sh term && \
   echo "term:term" | chpasswd
 EXPOSE 3000
 COPY . /app
-RUN apk add --update build-base python openssh && yarn
+RUN apk add --update build-base python openssh-client && yarn
 CMD node bin 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN adduser -D -h /home/term -s /bin/sh term && \
 EXPOSE 3000
 COPY . /app
 RUN apk add --update build-base python openssh && yarn
-CMD yarn start
+CMD node bin 


### PR DESCRIPTION
- Lower memory footprint by not using Yarn for starting the process
- Remove SSH server from container because only client is used for making connection