### PR TITLE
Embed as iframe for client with different domain not working (cors)

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -54,7 +54,7 @@ export default function createServer(
   const app = express();
   app
     .use(morgan('combined', { stream: logger.stream }))
-    .use(helmet())
+    .use(helmet({ frameguard: false }))
     .use(compression())
     .use(favicon(path.join(distDir, 'favicon.ico')))
     .use(`${basePath}/public`, express.static(distDir))


### PR DESCRIPTION
Error message: Refused to display in a frame because it set 'X-Frame-Options' to 'sameorigin'.

This line disables frameguard middleware in order to be able to embed wetty within an iframe again (f. e. for a client with a different domain)

