### PR TITLE
New feature to interface with authentication middleware

### DIFF
--- a/bin/nginx.template
+++ b/bin/nginx.template
@@ -46,6 +46,25 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
+
+    # Authenticate user via other services (e.g., oauth2 end-points)
+    #
+    # Configuration : 
+    #    - Configure a 'auth_request' directive for this server block
+    #    - Capture the authenticated username using 'auth_request_set'
+    #    - Set the 'remote-user' request header accordingly
+    #
+    # Example (using lasso as authentication middleware):
+    #
+    #    Add to server block:
+    #      auth_request /lasso-validate
+    #      auth_request_set $auth_user $upstream_http_x_lasso_user;
+    #
+    #    Add to /wetty location block
+    #      proxy_set_header remote-user $auth_user;
+    #
+    #    And configure a '/lasso-validate' location. See this blog for further 
+    #    guidance: https://developer.okta.com/blog/2018/08/28/nginx-auth-request
   }
 
   # gzip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: butlerx/wetty
     container_name: wetty
     tty: true
-    working_dir: /app
+    working_dir: /usr/src/app
     ports:
       - "3000:3000"
     environment:

--- a/src/server/term.ts
+++ b/src/server/term.ts
@@ -42,6 +42,17 @@ export default class Term {
   }
 
   public static login(socket: SocketIO.Socket): Promise<string> {
+
+    // Check request-header for username
+    let remoteUser = socket.request.headers['remote-user'];
+    if (remoteUser) {
+      return new Promise((resolve,reject) => {
+        resolve(remoteUser);
+      });
+    }
+
+    // Request carries no username information
+    // Create terminal and ask user for username
     const term = spawn(
       '/usr/bin/env',
       ['node', `${__dirname}/buffer.js`],


### PR DESCRIPTION
This feature checks the request header for a field 'remote-user' and if present uses the information provided in the request header instead of offering a terminal prompt asking for the username.

This allows to interface with authenticating middleware that provides user information. Due to security concerns, this pull request does not implement a method to pass password information or password-less rsa keys. Downstream authentication of the provided username remains the responsibility of the downstream service (e.g., by presenting the ssh prompt) or another managed approach.