### PR TITLE
Use relative paths for html resources, to allow reverse proxying

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,7 +29,8 @@ export default function createServer(
   const html = (
     req: express.Request,
     res: express.Response
-  ): express.Response =>
+  ): express.Response => {
+    const resourcePath = /^\/ssh\//.test(req.url) ? '../' : '';
     res.send(`<!doctype html>
 <html lang="en">
   <head>
@@ -37,7 +38,7 @@ export default function createServer(
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>WeTTy - The Web Terminal Emulator</title>
-    <link rel="stylesheet" href="${basePath}/public/index.css" />
+    <link rel="stylesheet" href="${resourcePath}public/index.css" />
   </head>
   <body>
     <div id="overlay">
@@ -47,9 +48,10 @@ export default function createServer(
       </div>
     </div>
     <div id="terminal"></div>
-    <script src="${basePath}/public/index.js"></script>
+    <script src="${resourcePath}public/index.js"></script>
   </body>
 </html>`);
+  }
 
   const app = express();
   app
@@ -59,12 +61,7 @@ export default function createServer(
     .use(favicon(path.join(distDir, 'favicon.ico')))
     .use(`${basePath}/public`, express.static(distDir))
     .use((req, res, next) => {
-      if (
-        req.url.substr(-1) === '/' &&
-        req.url.length > 1 &&
-        !/\?[^]*\//.test(req.url)
-      )
-        res.redirect(301, req.url.slice(0, -1));
+      if (req.url === basePath) res.redirect(301, req.url + '/');
       else next();
     })
     .get(basePath, html)


### PR DESCRIPTION
Fix for #57 
Option `--base` does not help with the issue - you want the paths to resources to be relative in the html, else no reverse possible unless you use with `--path` the path used in front of the proxy. But then the app will only work when used via the proxy, and not when it is accessed directly.
And to make the relative urls work, you need to have `/` at the end of the base path, so I am having to reverse the existing redirect to relocate eg `/wetty` to `/wetty/`.
Caveat: I don't know much js and zero typescript.