### PR TITLE
New startup option: --title

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@ if (require.main === module) {
           type: 'string',
           default: process.env.SSHUSER || '',
         },
+        title: {
+          demand: false,
+          description: 'window title',
+          type: 'string',
+          default: process.env.TITLE || 'WeTTy - The Web Terminal Emulator',
+        },
         sshauth: {
           demand: false,
           description:

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ export interface Options {
   base: string;
   host: string;
   port: number;
+  title: string;
   command?: string;
 }
 
@@ -33,6 +34,7 @@ export default class Server {
     base,
     host,
     port,
+    title,
     command,
     sslkey,
     sslcert,
@@ -54,10 +56,11 @@ export default class Server {
         host: sshhost,
         auth: sshauth,
         port: sshport,
+        title: title,
         pass: sshpass,
         key: sshkey,
       },
-      { base, host, port },
+      { base, host, port, title },
       command,
       { key: sslkey, cert: sslcert }
     );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,13 +17,13 @@ const distDir = path.join(__dirname, 'client');
 const trim = (str: string): string => str.replace(/\/*$/, '');
 
 export default function createServer(
-  { base, port, host }: Server,
+  { base, port, host, title }: Server,
   { key, cert }: SSLBuffer
 ): SocketIO.Server {
   const basePath = trim(base);
   events.emit(
     'debug',
-    `key: ${key}, cert: ${cert}, port: ${port}, base: ${base}`
+    `key: ${key}, cert: ${cert}, port: ${port}, base: ${base}, title: ${title}`
   );
 
   const html = (
@@ -36,7 +36,7 @@ export default function createServer(
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>WeTTy - The Web Terminal Emulator</title>
+    <title>${title}</title>
     <link rel="stylesheet" href="${basePath}/public/index.css" />
   </head>
   <body>


### PR DESCRIPTION
In my use case users may have several tabs with wetty against different containers. It is necessary to be able to differentiate them from the title.
Warning: I don't know typescript.