### PR TITLE
XSS Override

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,12 @@ if (require.main === module) {
           type: 'string',
           default: process.env.COMMAND || 'login',
         },
+        'no-helmet': {
+          demand: false,
+          description: 'disable helmet from placing security restrictions',
+          type: 'boolean',
+          default: false,
+        },
         help: {
           demand: false,
           alias: 'h',

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ if (require.main === module) {
           type: 'string',
           default: process.env.COMMAND || 'login',
         },
-        'no-helmet': {
+        bypasshelmet: {
           demand: false,
           description: 'disable helmet from placing security restrictions',
           type: 'boolean',

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "eslint-plugin-typescript": "^1.0.0-rc.1",
     "file-loader": "^3.0.1",
     "husky": "^1.3.1",
-    "lint-staged": "^6.1.1",
+    "lint-staged": "~8.2.0",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.11.0",
     "nodemon": "^1.14.10",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,7 +39,7 @@ export default class Server {
     command,
     sslkey,
     sslcert,
-    disableHelmet,
+    bypasshelmet,
   }: Options): Promise<void> {
     wetty
       .on('exit', ({ code, msg }: { code: number; msg: string }) => {
@@ -62,7 +62,7 @@ export default class Server {
         pass: sshpass,
         key: sshkey,
       },
-      { base, host, port, title, disableHelmet },
+      { base, host, port, title, bypasshelmet },
       command,
       { key: sslkey, cert: sslcert }
     );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,7 +17,7 @@ export interface Options {
   port: number;
   title: string;
   command?: string;
-  disableHelmet?: boolean;
+  bypasshelmet?: boolean;
 }
 
 interface CLI extends Options {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,6 +17,7 @@ export interface Options {
   port: number;
   title: string;
   command?: string;
+  disableHelmet?: boolean;
 }
 
 interface CLI extends Options {
@@ -38,6 +39,7 @@ export default class Server {
     command,
     sslkey,
     sslcert,
+    disableHelmet,
   }: Options): Promise<void> {
     wetty
       .on('exit', ({ code, msg }: { code: number; msg: string }) => {
@@ -56,11 +58,11 @@ export default class Server {
         host: sshhost,
         auth: sshauth,
         port: sshport,
-        title: title,
+        title,
         pass: sshpass,
         key: sshkey,
       },
-      { base, host, port, title },
+      { base, host, port, title, disableHelmet },
       command,
       { key: sslkey, cert: sslcert }
     );

--- a/src/server/interfaces.ts
+++ b/src/server/interfaces.ts
@@ -21,5 +21,5 @@ export interface Server {
   port: number;
   host: string;
   base: string;
-  disableHelmet: boolean;
+  bypasshelmet: boolean;
 }

--- a/src/server/interfaces.ts
+++ b/src/server/interfaces.ts
@@ -21,4 +21,5 @@ export interface Server {
   port: number;
   host: string;
   base: string;
+  disableHelmet: boolean;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,7 +17,7 @@ const distDir = path.join(__dirname, 'client');
 const trim = (str: string): string => str.replace(/\/*$/, '');
 
 export default function createServer(
-  { base, port, host, title }: Server,
+  { base, port, host, title, disableHelmet }: Server,
   { key, cert }: SSLBuffer
 ): SocketIO.Server {
   const basePath = trim(base);
@@ -49,7 +49,7 @@ export default function createServer(
     </div>
     <div id="options">
       <a class="toggler"
-         href="#" 
+         href="#"
          alt="Toggle options"><i class="fas fa-cogs"></i></a>
       <textarea class="editor"></textarea>
     </div>
@@ -61,7 +61,6 @@ export default function createServer(
   const app = express();
   app
     .use(morgan('combined', { stream: logger.stream }))
-    .use(helmet())
     .use(compression())
     .use(favicon(path.join(distDir, 'favicon.ico')))
     .use(`${basePath}/public`, express.static(distDir))
@@ -76,6 +75,10 @@ export default function createServer(
     })
     .get(basePath, html)
     .get(`${basePath}/ssh/:user`, html);
+
+  if (!disableHelmet) {
+    app.use(helmet());
+  }
 
   return socket(
     !isUndefined(key) && !isUndefined(cert)


### PR DESCRIPTION
This branch adds a new startup option `--bypasshelmet` to disable helmet middleware. This feature seems to be somewhat frequently requested, most recently in #192 and #164.

See HTTP headers when option is not passed (current default): 

```
HTTP/1.1 200 OK
Server: nginx
Date: Tue, 11 Jun 2019 12:46:59 GMT
Content-Type: text/html; charset=UTF-8
Transfer-Encoding: chunked
X-Powered-By: Express
ETag: W/"618-1448073568000"
Cache-Control: public, max-age=0
Last-Modified: Sat, 21 Nov 2015 02:39:28 GMT
X-XSS-Protections: 1; mode=block
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
Strict-Transport-Security:: max-age=604800; includeSubDomains; preload
Connection: Keep-Alive
Content-Encoding: gzip
Age: 0
```

And with  `--bypasshelmet`:

```HTTP/1.1 200 OK
Server: nginx
Date: Tue, 11 Jun 2019 13:27:47 GMT
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
X-Powered-By: Express
ETag: W/"3f5-rlF/xJ8GQ4k96BWUlhy6Be/CkXA"
Vary: Accept-Encoding
Connection: Keep-Alive
Content-Encoding: gzip
```

Also, due to an issue with any-observable in [`lint-staged` ](https://github.com/okonet/lint-staged/), I updated lint staged to version 8.2.0 in [ca50c52](https://github.com/krishnasrinivas/wetty/commit/ca50c52674329c5e819796186cfbe7824ee8fdac).