### PR TITLE
Fix regex test for /ssh/ when url has a base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetty",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "WeTTY = Web + TTY. Terminal access in browser over http/https",
   "homepage": "https://github.com/krishnasrinivas/wetty",
   "repository": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,7 +30,7 @@ export default function createServer(
     req: express.Request,
     res: express.Response
   ): express.Response => {
-    const resourcePath = /^\/ssh\//.test(req.url) ? '../' : '';
+    const resourcePath = /^\/ssh\//.test(req.url.replace(base, '/')) ? '../' : '';
     res.send(`<!doctype html>
 <html lang="en">
   <head>


### PR DESCRIPTION
When the request url contains a base path the regex test `/^\/ssh\//` would fail and the included index.css and index.js will return a 404 when the page is loaded.