### PR TITLE
Setting lower websocket ping interval values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetty",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "WeTTY = Web + TTY. Terminal access in browser over http/https",
   "homepage": "https://github.com/butlerx/wetty",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fs-extra": "^8.1.0",
     "helmet": "^3.20.1",
     "lodash": "^4.17.15",
-    "node-pty": "0.9.0-beta28",
+    "node-pty": "^0.9.0",
     "serve-favicon": "^2.5.0",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",

--- a/src/server/socketServer/index.ts
+++ b/src/server/socketServer/index.ts
@@ -69,6 +69,10 @@ export default function createServer(
             connection: 'http',
           });
         }),
-    { path: `${basePath}/socket.io` }
+    {
+      path: `${basePath}/socket.io`,
+      pingInterval: 3000,
+      pingTimeout: 7000
+    }
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5833,10 +5833,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pty@0.9.0-beta28:
-  version "0.9.0-beta28"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0-beta28.tgz#f086cea157b4640bace2ea787136fde73a26b273"
-  integrity sha512-qpLJE52oLRIOEvIeVmPzymn+zqUnYhPmlNjSRW60PwEZvhcdmazdP0IJcQfEK6ivwml14TzQLObMjEj8FFO7xg==
+node-pty@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
+  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
   dependencies:
     nan "^2.14.0"
 


### PR DESCRIPTION
In some cases, the default ping timeout (60 seconds) might be too long. That could result the closing of connection in some proxy server configuration due to inactivity.

Documentation: https://socket.io/docs/server-api/#

Please consider merging this PR.