### PR TITLE
Improvement to plain text file downloads 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetty",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "WeTTY = Web + TTY. Terminal access in browser over http/https",
   "homepage": "https://github.com/butlerx/wetty",
   "repository": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -99,6 +99,12 @@ socket.on('connect', () => {
       mimeType = typeData.mime;
       fileExt = typeData.ext;
     }
+    // Check if the buffer is ASCII
+    // Ref: https://stackoverflow.com/a/14313213
+    else if (/^[\x00-\x7F]*$/.test(fileCharacters)) { // eslint-disable-line no-control-regex
+      mimeType = 'text/plain';
+      fileExt = 'txt';
+    }
     const fileName = `file-${new Date()
       .toISOString()
       .split('.')[0]


### PR DESCRIPTION
Detect plain text files and assign them an extension of .txt instead of defaulting to octet-stream