### PR TITLE
Fixed wetty import

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const yargs = require('yargs');
 const wetty = require('./dist').default;
 
-module.exports = wetty.wetty;
+module.exports = wetty;
 
 /**
  * Check if being run by cli or require

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "contributor": "all-contributors",
     "dev": "NODE_ENV=development concurrently --kill-others --success first \"babel-node node_modules/.bin/webpack --watch\" \"nodemon .\"",
     "lint": "eslint --ext .ts,.js .",
-    "prepublishOnly": "NODE_ENV=production yarn build",
+    "postinstall": "yarn; NODE_ENV=production yarn build",
     "start": "node .",
     "test": "mocha -r babel-register-ts src/**/*.spec.ts"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "contributor": "all-contributors",
     "dev": "NODE_ENV=development concurrently --kill-others --success first \"babel-node node_modules/.bin/webpack --watch\" \"nodemon .\"",
     "lint": "eslint --ext .ts,.js .",
-    "postinstall": "yarn; NODE_ENV=production yarn build",
+    "postinstall": "NODE_ENV=production yarn build",
     "start": "node .",
     "test": "mocha -r babel-register-ts src/**/*.spec.ts"
   },


### PR DESCRIPTION
In the changes from 1.1.4 to 1.3 the src/server/index.ts lost it's getter for wetty.
`
public static get wetty(): WeTTy {
    return wetty;
  }
`

this resulted in a undefined return upon import.