### PR TITLE
Fix wetty import

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const yargs = require('yargs');
 const wetty = require('./dist').default;
 
-module.exports = wetty.wetty;
+module.exports = wetty;
 
 /**
  * Check if being run by cli or require


### PR DESCRIPTION
In the changes from 1.1.4 to 1.3 the src/server/index.ts lost it's getter for wetty.
```
public static get wetty(): WeTTy {
    return wetty;
  }
```
this resulted in a undefined return upon import.