### PR TITLE
Hide xterm scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetty",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "WeTTY = Web + TTY. Terminal access in browser over http/https",
   "homepage": "https://github.com/butlerx/wetty",
   "repository": {

--- a/src/client/wetty.scss
+++ b/src/client/wetty.scss
@@ -101,3 +101,7 @@ body {
     color: $black;
   }
 }
+
+.xterm .xterm-viewport {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
I've noticed that there's a strange partial scroll bar in the bottom right corner of wetty windows in Chrome. It's from xterm, this PR fixes it while still maintaining the ability to scroll up and down. 

![wetty-scroll](https://user-images.githubusercontent.com/6703966/74199327-f4eb2a00-4cb7-11ea-9251-0214214201aa.png)
