### PR TITLE
Check for extended ASCII characters for plaintext files

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -101,7 +101,7 @@ socket.on('connect', () => {
     }
     // Check if the buffer is ASCII
     // Ref: https://stackoverflow.com/a/14313213
-    else if (/^[\x00-\x7F]*$/.test(fileCharacters)) { // eslint-disable-line no-control-regex
+    else if (/^[\x00-\xFF]*$/.test(fileCharacters)) { // eslint-disable-line no-control-regex
       mimeType = 'text/plain';
       fileExt = 'txt';
     }


### PR DESCRIPTION
I should have originally checked for the extended ASCII set. I ran into an issue with this in production recently. This PR fixes it.