### PR TITLE
Document limitation of Systemd (WorkingDirectory)

### DIFF
--- a/docs/service.md
+++ b/docs/service.md
@@ -27,3 +27,6 @@ like this:
 ```systemd
 exec sudo -u root wetty -p 80 >> /var/log/wetty.log 2>&1
 ```
+
+Systemd requires an absolute path for a unit's WorkingDirectory, consquently `$HOME` 
+will need updating to an absolute path in the `wetty.service` file. 


### PR DESCRIPTION
Update documentation expressing limitation of systemd, which prevents the system file as detailed from working without a change to the `WorkingDirectory`. Specifically the use of relative path names.