### PR TITLE
Docker image documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Options:
 
 Open your browser on `http://yourserver:3000/wetty` and you will prompted to
 login. Or go to `http://yourserver:3000/wetty/ssh/<username>` to specify the
-user before hand.
+user beforehand.
 
 If you run it as root it will launch `/bin/login` (where you can specify the
 user name), else it will launch `ssh` and connect by default to `localhost`. The
@@ -80,6 +80,24 @@ option, the SSH port using the `--ssh-port` option and the SSH user using the
 Check out the
 [Flags docs](https://github.com/butlerx/wetty/blob/master/docs/flags.md) for a
 full list of flags
+
+### Docker container
+
+To use wetty as a docker container, a docker image is available on
+[docker hub](https://hub.docker.com/r/wettyoss/wetty). To run this image, use
+
+```sh
+docker run --rm -p 3000:3000 wettyoss/wetty --ssh-host=<YOUR-IP>
+```
+
+and you will be able to open a ssh session to the host given by `YOUR-IP` under
+the URL [http://localhost:3000/wetty](http://localhost:3000/wetty).
+
+It is recommended to drive wetty behind a reverse proxy to have HTTPS security
+and possibly Let’s Encrypt support. Popular containers to achieve this are
+[nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) and
+[traefik](https://traefik.io/traefik/). For traefik there is an example
+docker-compose file in the containers directory.
 
 ## FAQ
 

--- a/containers/docker-compose.traefik.yml
+++ b/containers/docker-compose.traefik.yml
@@ -1,5 +1,11 @@
 version: '2'
 
+# Sample docker compose file to demonstrate the usage of wetty behind a reverse
+# proxy, optionally with Let's Encrypt based SSL certificate
+#
+# For SSL support, uncomment the commented lines. Consult traefik documentation
+# for features like automatic forward from HTTP to HTTPS etc.
+
 services:
   wetty:
     image: wettyoss/wetty
@@ -9,11 +15,21 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.wetty.rule=Host(`wetty.example.com`)"
+      # - "traefik.http.routers.wetty.tls.certResolver=default"
+      # - "traefik.http.routers.wetty.tls=true"
 
   reverse-proxy:
     image: traefik
-    command: --providers.docker
+    command:
+      - --providers.docker
+      - --entryPoints.web.address=:80
+      # - --entryPoints.websecure.address=:443
+      # - --certificatesResolvers.default.acme.email=your-email@example.com
+      # - --certificatesResolvers.default.acme.storage=acme.json
+      # - --certificatesResolvers.default.acme.httpChallenge.entryPoint=web
     ports:
       - "80:80"
+      # - "443:443"
+
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/containers/docker-compose.traefik.yml
+++ b/containers/docker-compose.traefik.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  wetty:
+    image: wettyoss/wetty
+    command:
+      - --base=/
+      - --ssh-host=ssh.example.com
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wetty.rule=Host(`wetty.example.com`)"
+
+  reverse-proxy:
+    image: traefik
+    command: --providers.docker
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Since the docker configuration in wetty is more or less the same as in my docker image, I just added some documentation and a docker-compose example to support people on docker hub.

I will deprecate my image now and provide a link to your image. Keep it up!