### PR TITLE
Support docker multi architecture builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           context: .
           file: containers/wetty/Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
As in the issue https://github.com/butlerx/wetty/issues/375.

Just expanding the platforms on build and push step should be enough. The change I made will increase the build time a little bit, but wetty is a pretty small up so it shouldn't be really long after the cache is present. I included the most used architectures, since probably there won't be many users looking for the rest ones.

I tested the build locally, the base image in your Dockerfile supports all the listed architectures, so the pipeline should run correctly.

Here after inspecting logs for QUEMU step we can see the available architectures: https://github.com/butlerx/wetty/runs/5005410338?check_suite_focus=true

Here are the docs how to build for multi platform: https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md

Here more details on the platforms input: 
https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#platform

Great app, let me know if you have any questions!