### PR TITLE
xframe-disabled

### DIFF
--- a/src/server/socketServer/security.ts
+++ b/src/server/socketServer/security.ts
@@ -18,6 +18,7 @@ export const policies =
           ],
         },
       },
+      frameguard: false
     };
     if (!allowIframe) args.frameguard = { action: 'sameorigin' };
 


### PR DESCRIPTION
This disables the xframe header from showing, but CSP still blocks in some cases. Probably need an argument for defaultSrc.