### PR TITLE
Patch for incorrect `this` keyword in resize handler causing an exception

### DIFF
--- a/src/client/wetty.ts
+++ b/src/client/wetty.ts
@@ -20,7 +20,7 @@ socket.on('connect', () => {
 
   if (!_.isNull(overlay)) overlay.style.display = 'none';
   window.addEventListener('beforeunload', verifyPrompt, false);
-  window.addEventListener('resize', term.resizeTerm, false);
+  window.addEventListener('resize', () => { term.resizeTerm() }, false);
 
   term.resizeTerm();
   term.focus();

--- a/src/client/wetty/term.ts
+++ b/src/client/wetty/term.ts
@@ -41,7 +41,7 @@ export function terminal(socket: Socket): Term | undefined {
   termElement.innerHTML = '';
   term.open(termElement);
   configureTerm(term);
-  window.onresize = term.resizeTerm;
+  window.onresize = () => { term.resizeTerm() };
   window.wetty_term = term;
   return term;
 }


### PR DESCRIPTION
As discussed here [MDN: the value of "this" within the handler](https://developer.mozilla.org/en-US/docs/web/api/eventtarget/addeventlistener#the_value_of_this_within_the_handler), passing an object's method to `addEventListener` as-is, like is currently done with `term.resizeTerm`, will not maintain the `this` keyword context within the function when the event is triggered. The function tries to call `this.refresh()` which doesn't exist on the global object which `this` now refers to, resulting in an exception being thrown (it would also go on to access other properties of `this` which would result in an error too). Could use `term.resizeTerm.bind(term)` to fix the issue if this is preferred to an anonymous function, but in this pull request I've just wrapped the two calls to `resizeTerm` in an arrow function.

![taylor8294_patch1_err](https://user-images.githubusercontent.com/6105031/163203848-8d966700-48cf-4fee-b4e3-95c7b8ea2a78.png)