### PR TITLE
escape special chars in username: `- . \ @`

### DIFF
--- a/src/server/shared/shell.spec.ts
+++ b/src/server/shared/shell.spec.ts
@@ -8,6 +8,11 @@ describe('Values passed to escapeShell should be safe to pass woth sub processes
     expect(cmd).to.equal('testechohello');
   });
 
+  it('should allow usernames with special characters', () => {
+    const cmd = escapeShell('bob.jones\\COM@ultra-machine_dir');
+    expect(cmd).to.equal('bob.jones\\COM@ultra-machine_dir');
+  });
+
   it('should ensure args cant be flags', () => {
     const cmd = escapeShell("-oProxyCommand='bash' -c `wget localhost:2222`");
     expect(cmd).to.equal('oProxyCommandbash-cwgetlocalhost2222');

--- a/src/server/shared/shell.ts
+++ b/src/server/shared/shell.ts
@@ -1,2 +1,3 @@
 export const escapeShell = (username: string): string =>
+  // eslint-disable-next-line no-useless-escape
   username.replace(/^-|[^a-zA-Z0-9_\\\-\.\@-]/g, '');

--- a/src/server/shared/shell.ts
+++ b/src/server/shared/shell.ts
@@ -1,2 +1,2 @@
 export const escapeShell = (username: string): string =>
-  username.replace(/^-|[^a-zA-Z0-9_-]/g, '');
+  username.replace(/^-|[^a-zA-Z0-9_\\\-\.\@-]/g, '');


### PR DESCRIPTION
Regarding https://github.com/butlerx/wetty/issues/387 - for my intended use of wetty we are all using usernames with periods in them. This PR allows the following characters for usernames: `-`, `.`, `\`, and `@` I presume there may be a security reason that these are not allowed, so if this PR is not accepted, would one with an `--insecure-characters` flag possibly work?