### PR TITLE
make wetty architecture independent

### DIFF
--- a/containers/ssh/Dockerfile
+++ b/containers/ssh/Dockerfile
@@ -1,10 +1,4 @@
-ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
-    elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64/v8" ]; then ARCHITECTURE=arm64v8; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; \
-    else ARCHITECTURE=amd64; \
-    fi
-FROM ${ARCHITECTURE}/alpine:latest
+FROM alpine
+#FROM --platform=$BUILDPLATFORM alpine AS build
 RUN adduser -D -h /home/term -s /bin/sh term && \
     ( echo "term:term" | chpasswd )

--- a/containers/ssh/Dockerfile
+++ b/containers/ssh/Dockerfile
@@ -1,3 +1,10 @@
-FROM sickp/alpine-sshd:latest
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
+    elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; \
+    elif [ "$TARGETPLATFORM" = "linux/arm/v8" ]; then ARCHITECTURE=arm64v8; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; \
+    else ARCHITECTURE=amd64; \
+    fi
+FROM ${ARCHITECTURE}/alpine:latest
 RUN adduser -D -h /home/term -s /bin/sh term && \
     ( echo "term:term" | chpasswd )

--- a/containers/ssh/Dockerfile
+++ b/containers/ssh/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; \
     elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; \
-    elif [ "$TARGETPLATFORM" = "linux/arm/v8" ]; then ARCHITECTURE=arm64v8; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64/v8" ]; then ARCHITECTURE=arm64v8; \
     elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; \
     else ARCHITECTURE=amd64; \
     fi

--- a/containers/wetty/Dockerfile
+++ b/containers/wetty/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 RUN yarn && \
     yarn build && \
-    yarn install --production --ignore-scripts --prefer-offline
+    yarn install --production --ignore-scripts --prefer-offline  --ignore-engines
 
 FROM node:current-alpine
 LABEL maintainer="butlerx@notthe.cloud"


### PR DESCRIPTION
I was unable to load the docker container with the current implementation on raspberry pi.
Therefore, I thought it would be better to make the wetty Docker implementation to be architecture independent.