### PR TITLE
flow control

### DIFF
--- a/src/client/wetty/flowcontrol.ts
+++ b/src/client/wetty/flowcontrol.ts
@@ -1,12 +1,11 @@
 /**
  * Flow control client side.
  * For low impact on overall throughput simply commits every `ackBytes`
- * (default 2^19). The value should correspond to chosen values on server side
- * to avoid perma blocking.
+ * (default 2^18).
  */
 export class FlowControlClient {
   public counter = 0;
-  public ackBytes = 524288;
+  public ackBytes = 262144;
 
   constructor(ackBytes?: number) {
     if (ackBytes) {

--- a/src/client/wetty/flowcontrol.ts
+++ b/src/client/wetty/flowcontrol.ts
@@ -1,0 +1,25 @@
+/**
+ * Flow control client side.
+ * For low impact on overall throughput simply commits every `ackBytes`
+ * (default 2^19). The value should correspond to chosen values on server side
+ * to avoid perma blocking.
+ */
+export class FlowControlClient {
+  public counter = 0;
+  public ackBytes = 524288;
+
+  constructor(ackBytes?: number) {
+    if (ackBytes) {
+      this.ackBytes = ackBytes;
+    }
+  }
+
+  public needsCommit(length: number): boolean {
+    this.counter += length;
+    if (this.counter >= this.ackBytes) {
+      this.counter -= this.ackBytes;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/server/flowcontrol.ts
+++ b/src/server/flowcontrol.ts
@@ -44,8 +44,8 @@ export function tinybuffer(socket: Socket, timeout: number, maxSize: number) {
  * indicating its final processing on xtermjs side. Returns `true`
  * if the underlying PTY should be resumed.
  *
- * Note: Chosen values for ackBytes, low and high must be within
- * reach of the chosen value of ackBytes on client side, otherwise
+ * Note: Chosen values for low and high must be within reach of the
+ * chosen value of ackBytes on client side, otherwise
  * flow control may block forever sooner or later.
  *
  * The default values are chosen quite high to lower negative impact on overall
@@ -55,14 +55,10 @@ export function tinybuffer(socket: Socket, timeout: number, maxSize: number) {
  */
 export class FlowControlServer {
   public counter = 0;
-  public ackBytes = 524288; // 2^19
-  public low = 524288;      // 2^19
-  public high = 4194304;    // 2^22
+  public low = 524288;      // 2^19 --> 2x ackBytes from frontend
+  public high = 2097152;    // 2^21 --> 8x ackBytes from frontend
 
-  constructor(ackBytes?: number, low?: number, high?: number) {
-    if (ackBytes) {
-      this.ackBytes = ackBytes;
-    }
+  constructor(low?: number, high?: number) {
     if (low) {
       this.low = low;
     }

--- a/src/server/flowcontrol.ts
+++ b/src/server/flowcontrol.ts
@@ -1,0 +1,85 @@
+import { Socket } from 'socket.io';
+
+/**
+ * tinybuffer to lower message pressure on the websocket.
+ * Incoming data from PTY will be held back at most for `timeout` microseconds.
+ * If the accumulated data exceeds `maxSize` the message will be sent
+ * immediately.
+ */
+export function tinybuffer(socket: Socket, timeout: number, maxSize: number) {
+  const s: string[] = [];
+  let length = 0;
+  let sender: NodeJS.Timeout | null = null;
+  return (data: string) => {
+    s.push(data);
+    length += data.length;
+    if (length > maxSize) {
+      socket.emit('data', s.join(''));
+      s.length = 0;
+      length = 0;
+      if (sender) {
+        clearTimeout(sender);
+        sender = null;
+      }
+    }
+    else if (!sender) {
+      sender = setTimeout(() => {
+        socket.emit('data', s.join(''));
+        s.length = 0;
+        length = 0;
+        sender = null;
+      }, timeout);
+    }
+  };
+}
+
+/**
+ * Flow control - server side.
+ * Does basic low to high watermark flow control.
+ *
+ * `account` should be fed by new chunk length and returns `true`,
+ * if the underlying PTY should be paused.
+ *
+ * `commit` should be fed by the length value of an 'ack' message
+ * indicating its final processing on xtermjs side. Returns `true`
+ * if the underlying PTY should be resumed.
+ *
+ * Note: Chosen values for ackBytes, low and high must be within
+ * reach of the chosen value of ackBytes on client side, otherwise
+ * flow control may block forever sooner or later.
+ *
+ * The default values are chosen quite high to lower negative impact on overall
+ * throughput. If you need snappier keyboard response under high data pressure
+ * (e.g. pressing Ctrl-C while `yes` is running), lower the values.
+ * This furthermore depends a lot on the general latency of your connection.
+ */
+export class FlowControlServer {
+  public counter = 0;
+  public ackBytes = 524288; // 2^19
+  public low = 524288;      // 2^19
+  public high = 4194304;    // 2^22
+
+  constructor(ackBytes?: number, low?: number, high?: number) {
+    if (ackBytes) {
+      this.ackBytes = ackBytes;
+    }
+    if (low) {
+      this.low = low;
+    }
+    if (high) {
+      this.high = high;
+    }
+  }
+
+  public account(length: number): boolean {
+    const old = this.counter;
+    this.counter += length;
+    return old < this.high && this.counter > this.high;
+  }
+
+  public commit(length: number): boolean {
+    const old = this.counter;
+    this.counter -= length;
+    return old > this.low && this.counter < this.low;
+  }
+}

--- a/src/server/spawn.ts
+++ b/src/server/spawn.ts
@@ -26,8 +26,14 @@ export async function spawn(
       .removeAllListeners('resize')
       .removeAllListeners('input');
   });
-  term.on('data', (data: string) => {
-    socket.emit('data', data);
+  const send = tinybuffer(socket, 2, 524288);
+  const fcServer = new FlowControlServer();
+  term.on('data', (data: any) => {
+    //socket.emit('data', data);
+    send(data);
+    if (fcServer.account(data.length)) {
+      term.pause();
+    }
   });
   socket
     .on('resize', ({ cols, rows }) => {
@@ -39,5 +45,82 @@ export async function spawn(
     .on('disconnect', () => {
       term.kill();
       logger.info('Process exited', { code: 0, pid });
+    })
+    .on('commit', size => {
+      if (fcServer.commit(size)) {
+        term.resume();
+      }
     });
+}
+
+/**
+ * tinybuffer to lower message pressure on the websocket.
+ * Incoming data from PTY will be held back at most for `timeout` microseconds.
+ * If the accumulated data exceeds `maxSize` the message will be sent
+ * immediately.
+ */
+function tinybuffer(socket: any, timeout: number, maxSize: number) {
+  const s: string[] = [];
+  let length = 0;
+  let sender: any = null;
+  return (data: string) => {
+    s.push(data);
+    length += data.length;
+    if (length > maxSize) {
+      socket.emit('data', s.join(''));
+      s.length = 0;
+      length = 0;
+      if (sender) {
+        clearTimeout(sender);
+        sender = null;
+      }
+    }
+    else if (!sender) {
+      sender = setTimeout(() => {
+        socket.emit('data', s.join(''));
+        s.length = 0;
+        length = 0;
+        sender = null;
+      }, timeout);
+    }
+  };
+}
+
+/**
+ * Flow control - server side.
+ * Does basic low to high watermark flow control.
+ *
+ * `account` should be fed by new chunk length and returns `true`,
+ * if the underlying PTY should be paused.
+ *
+ * `commit` should be fed by the length value of an 'ack' message
+ * indicating its final processing on xtermjs side. Returns `true`
+ * if the underlying PTY should be resumed.
+ *
+ * Note: Chosen values for ackBytes, low and high must be within
+ * reach of the chosen value of ackBytes on client side, otherwise
+ * flow control may block forever sooner or later.
+ *
+ * The default values are chosen quite high to lower negative impact on overall
+ * throughput. If you need snappier keyboard response under high data pressure
+ * (e.g. pressing Ctrl-C while `yes` is running), lower the values.
+ * This furthermore depends a lot on the general latency of your connection.
+ */
+class FlowControlServer {
+  public counter = 0;
+  constructor(
+    public ackBytes: number = 524288, // 2^19
+    public low: number = 524288,      // 2^19
+    public high: number = 4194304     // 2^22
+  ) {}
+  public account(length: number): boolean {
+    const old = this.counter;
+    this.counter += length;
+    return old < this.high && this.counter > this.high;
+  }
+  public commit(length: number): boolean {
+    const old = this.counter;
+    this.counter -= length;
+    return old > this.low && this.counter < this.low;
+  }
 }

--- a/src/server/spawn.ts
+++ b/src/server/spawn.ts
@@ -28,8 +28,7 @@ export async function spawn(
   });
   const send = tinybuffer(socket, 2, 524288);
   const fcServer = new FlowControlServer();
-  term.on('data', (data: any) => {
-    //socket.emit('data', data);
+  term.on('data', (data: string) => {
     send(data);
     if (fcServer.account(data.length)) {
       term.pause();


### PR DESCRIPTION
May fix #424.

Implements flow control for xterm.js and FileDownload. Also adds a tiny prebuffer on server side to lower websocket chunk pressure (2ms timeout).

Can be tested with:
- `cat /dev/zero` - does not kill terminal anymore; Ctrl-C works in reasonable time
- `yes` - Ctrl-C works within reasonable time
- `ls -lR /usr` finishes ~2 times faster (testing the tiny buffer)