### PR TITLE
Fix env util invocation on non-GNU environments.

### DIFF
--- a/src/server/spawn.ts
+++ b/src/server/spawn.ts
@@ -3,7 +3,7 @@ import isUndefined from 'lodash/isUndefined.js';
 import pty from 'node-pty';
 import { logger as getLogger } from '../shared/logger.js';
 import { xterm } from './shared/xterm.js';
-import { envVersion } from './spawn/env.js';
+import { envVersionOr } from './spawn/env.js';
 import { tinybuffer, FlowControlServer } from './flowcontrol.js';
 
 export async function spawn(
@@ -11,7 +11,7 @@ export async function spawn(
   args: string[],
 ): Promise<void> {
   const logger = getLogger();
-  const version = await envVersion();
+  const version = await envVersionOr(0);
   const cmd = version >= 9 ? ['-S', ...args] : args;
   logger.debug('Spawning PTY', { cmd });
   const term = pty.spawn('/usr/bin/env', cmd, xterm);

--- a/src/server/spawn/env.ts
+++ b/src/server/spawn/env.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 
-export const envVersion = (): Promise<number> =>
+const envVersion = (): Promise<number> =>
   new Promise((resolve, reject) => {
     exec('/usr/bin/env --version', (error, stdout, stderr): void => {
       if (error) {
@@ -17,3 +17,6 @@ export const envVersion = (): Promise<number> =>
       );
     });
   });
+
+export const envVersionOr = (fallback: number): Promise<number> =>
+  envVersion().catch(() => fallback);


### PR DESCRIPTION
If `env --version` invocation crashes, returns unexpected results, or otherwise fails, allow a default fallback version to be used instead of crashing the whole connection, so WeTTY can fall back on "safe" compatible default behavior.

This should fix #396.

