### PR TITLE
Fix socket.io failures with ~/ssh/:user paths

### DIFF
--- a/src/client/wetty/socket.ts
+++ b/src/client/wetty/socket.ts
@@ -2,7 +2,7 @@ import io from 'socket.io-client';
 
 export const trim = (str: string): string => str.replace(/\/*$/, '');
 
-const socketBase = trim(window.location.pathname).replace('/ssh/[^/]+$/', '');
+const socketBase = trim(window.location.pathname).replace(/ssh\/[^/]+$/, '');
 export const socket = io(window.location.origin, {
   path: `${trim(socketBase)}/socket.io`,
 });


### PR DESCRIPTION
Update: turned out to be a simple "typo" kind of fix.

~~When using {basePath}/ssh/:user URLs to provide a user on connecting, WeTTY attempts to connect to
{basePath}/ssh/:user/socket.io instead of the expected {basePath}/socket.io, where Socket.IO is actually listening.~~

~~It does not look simple to make Socket.IO listen on a second path.  It also does not look simple to detect whether we're in a ssh/user path or not and generate different relative URLs, and attempting to use an absolute path will cause issues for some reverse proxy setups.  The simplest solution is just to capture any */socket.io path and send it to Socket.IO via URL rewriting.~~

This should fix #395