### PR TITLE
Update development flow to be less confusing

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,8 +13,13 @@ $ yarn build
 
 ## Development Env
 
-To run WeTTY in dev mode you can run `yarn dev` this will build latest version
-of WeTTY and start the server pointing at `localhost` on port `22`. The Dev
-server will rebuild WeTTY when ever a file is edited and restart the server with
-the new build. Any current ssh session in WeTTY will be killed and the user
-logged out.
+To run WeTTY in dev mode you can run `yarn dev`.
+
+WeTTY will then be served from `http://localhost:3000/wetty` on your machine.
+
+The server will be using the [`conf/config.json5`](../conf/config.json5) config
+file and be pointing at `localhost` on port `22` .
+
+The Dev server will rebuild WeTTY when ever a file is edited and restart the
+server with the new build. Any current ssh session in WeTTY will be killed and
+the user logged out.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "snowpack build",
     "clean": "rm -rf build yarn-error.log",
     "contributor": "all-contributors",
-    "dev": "NODE_ENV=development concurrently --kill-others --success first \"snowpack dev\" \"nodemon .\"",
+    "dev": "NODE_ENV=development concurrently --kill-others --success first \"snowpack build --watch\" \"nodemon . --conf conf/config.json5\"",
     "docker-compose-entrypoint": "ssh-keyscan -H wetty-ssh >> ~/.ssh/known_hosts; yarn start",
     "lint": "eslint src",
     "start": "NODE_ENV=production node .",


### PR DESCRIPTION
close issue #432

- use `snowpack build --watch` rather then `snowpack dev`
- Update `docs/developments.md` to reflect the acutal development
  environment
