### PR TITLE
Add `allowIframe` environment variable for Docker

### DIFF
--- a/docs/atoz.md
+++ b/docs/atoz.md
@@ -407,6 +407,7 @@ SSHPORT
 KNOWNHOSTS
 FORCESSH
 COMMAND
+ALLOWIFRAME
 ```
 
 These can be used in the following way

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -18,7 +18,7 @@ export const serverDefault: Server = {
   port: parseInt(process.env.PORT || '3000', 10),
   host: '0.0.0.0',
   title: process.env.TITLE || 'WeTTY - The Web Terminal Emulator',
-  allowIframe: false,
+  allowIframe: process.env.ALLOWIFRAME === 'true' || false,
 };
 
 export const forceSSHDefault = process.env.FORCESSH === 'true' || false;


### PR DESCRIPTION
There is no other easy way to enable iframes in Docker otherwise.