### PR TITLE
Implement request HTTP Header to env vars propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Options:
   --port, -p      wetty listen port                                     [number]
   --host          wetty listen host                                     [string]
   --command, -c   command to run in shell                               [string]
+  -E, --env-from-header     Pass header information to command as env variable;
+                            e.g., --env-from-header HTTP_HOST:host       [array]
   --allow-iframe  Allow wetty to be embedded in an iframe, defaults to allowing
                   same origin                                          [boolean]
 ```

--- a/conf/config.json5
+++ b/conf/config.json5
@@ -23,6 +23,10 @@
   ssl:{
     key: 'ssl.key',
     cert: 'ssl.cert',
+  },
+  envFromHeaders: {                             // Export request HTTP headers as env vars supplied to command
+    'ENV_VAR_NAME': 'lowercase_header_name',
+    'ORIG_ADDR': 'x-forwarded-for',             // Get original IP when behind a reverse proxy
   }
   */
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,7 @@ Starts WeTTY Server
 | [ssl]                     | `Object`  |               | SSL settings                                                                                                           |
 | [ssl.key]                 | `string`  |               | Path to ssl key                                                                                                        |
 | [ssl.cert]                | `string`  |               | Path to ssl cert                                                                                                       |
+| [envFromHeaders]          | `Object`  |               | Key/value pairs of env vars to export to the executed command; e.g., `{HTTP_HOST:'host'}`                              |
 
 ### "connection"
 

--- a/docs/apache.md
+++ b/docs/apache.md
@@ -40,6 +40,10 @@ E.g: You can ask the Idp to return a sAMAccountName within the SAML2Response
 NameID, and provision beforehand those allowed users on the OS WeTTY is running
 on.
 
+You can also use `--env-from-header` configuration (see command-line args or config)
+along with `--command` to export a `remote-user` HTTP header to the executed command.
+You will need then to handle the authentication process yourself using a custom script.
+
 ### SAML2 Metadata generation
 
 SAML2 metadata needs to be generated for this new service on the server and

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -36,3 +36,17 @@ with `--base`.
 
 **Do not set this to `/ssh/${something}`, as this will break username matching
 code.**
+
+## Expose HTTP Headers as env vars
+
+If you wish to expose one (or many) request HTTP Headers as environment variables,
+you can specify that using the `--env-from-header` flag. The syntax is 
+`--env-from-header VARNAME:http_header_lowercase`.
+
+You can export as many variables as you want by using the flag multiple times. 
+However, the flag is useless if not combined with `--command` that could use these
+variables to achieve what you want to do.
+
+This flag is particularly if wetty is behind a reverse proxy and allow you to propagate
+some authentication information (username, ssh key ...) in the most secure way (command-line
+is not safe most of the same for sensitive information).

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,11 @@ const opts = yargs(hideBin(process.argv))
     description: 'command to run in shell',
     type: 'string',
   })
+  .option('env-from-header', {
+    alias: 'E',
+    description: 'Pass header information to command as env variable; e.g., --env-from-header HTTP_HOST:host',
+    type: 'array',
+  })
   .option('allow-iframe', {
     description:
       'Allow WeTTY to be embedded in an iframe, defaults to allowing same origin',
@@ -122,7 +127,7 @@ if (!opts.help) {
     .then((config) => mergeCliConf(opts, config))
     .then((conf) => {
       setLevel(conf.logLevel);
-      start(conf.ssh, conf.server, conf.command, conf.forceSSH, conf.ssl);
+      start(conf.ssh, conf.server, conf.command, conf.forceSSH, conf.ssl, conf.envFromHeaders);
     })
     .catch((err: Error) => {
       logger().error('error in server', { err });

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -8,8 +8,9 @@ import {
   forceSSHDefault,
   defaultCommand,
   defaultLogLevel,
+  envFromHeadersDefault,
 } from './defaults.js';
-import type { Config, SSH, Server, SSL } from './interfaces';
+import type { Config, SSH, Server, SSL, EnvHeaders } from './interfaces';
 import type winston from 'winston';
 import type { Arguments } from 'yargs';
 
@@ -76,6 +77,7 @@ export async function loadConfigFile(filepath?: string): Promise<Config> {
       command: defaultCommand,
       forceSSH: forceSSHDefault,
       logLevel: defaultLogLevel,
+      envFromHeaders: envFromHeadersDefault,
     };
   }
   const content = await fs.readFile(path.resolve(filepath));
@@ -93,6 +95,9 @@ export async function loadConfigFile(filepath?: string): Promise<Config> {
       : ensureBoolean(parsed.forceSSH),
     ssl: parsed.ssl,
     logLevel: parseLogLevel(defaultLogLevel, parsed.logLevel),
+    envFromHeaders: isUndefined(parsed.envFromHeaders)
+      ? envFromHeadersDefault
+      : Object.assign(envFromHeadersDefault, parsed.envFromHeaders),
   };
 }
 
@@ -149,6 +154,11 @@ export function mergeCliConf(opts: Arguments, config: Config): Config {
       allowIframe: opts['allow-iframe'],
     }) as Server,
     command: isUndefined(opts.command) ? config.command : `${opts.command}`,
+    envFromHeaders: isUndefined(opts['env-from-header'])
+      ? config.envFromHeaders
+      : Object.fromEntries(
+          (opts['env-from-header'] as string[]).map((s:string) => s.split(':'))
+        ) as EnvHeaders,
     forceSSH: isUndefined(opts['force-ssh'])
       ? config.forceSSH
       : ensureBoolean(opts['force-ssh']),

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -1,5 +1,5 @@
 import { isDev } from './env.js';
-import type { SSH, Server } from './interfaces';
+import type { SSH, Server, EnvHeaders } from './interfaces';
 
 export const sshDefault: SSH = {
   user: process.env.SSHUSER || '',
@@ -24,3 +24,4 @@ export const serverDefault: Server = {
 export const forceSSHDefault = process.env.FORCESSH === 'true' || false;
 export const defaultCommand = process.env.COMMAND || 'login';
 export const defaultLogLevel = isDev ? 'debug' : 'http';
+export const envFromHeadersDefault: EnvHeaders = {};

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -32,6 +32,10 @@ export interface Server {
   allowIframe: boolean;
 }
 
+export interface EnvHeaders {
+  [s: string]: string;
+}
+
 export interface Config {
   ssh: SSH;
   server: Server;
@@ -39,4 +43,5 @@ export interface Config {
   command: string;
   logLevel: typeof winston.level;
   ssl?: SSL;
+  envFromHeaders?: EnvHeaders;
 }


### PR DESCRIPTION
This pull request is a response to the issue #483 that I created earlier.

The purpose is to make configurable to export *specific headers* to the command script. It could be useful to perform custom user authentications for example.

The pull request contains : 
* The feature source code
* All created/updated documentation (flags, apache, API ...) related to the feature