### PR TITLE
fix docker build by adding node-gyp

### DIFF
--- a/containers/wetty/Dockerfile
+++ b/containers/wetty/Dockerfile
@@ -2,6 +2,7 @@ FROM node:current-alpine as builder
 RUN apk add -U build-base python3
 WORKDIR /usr/src/app
 COPY . /usr/src/app
+RUN yarn global add node-gyp
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
This fix changes the docker build.

Before making this change, Building the wetty image results in failure as it is missing node-gyp:

```
wetty on  fix-docker-build [?] is 📦 v2.6.0 via  v20.4.0 
❯ git switch main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

wetty on  main [?] is 📦 v2.6.0 via  v20.4.0 
❯ docker build . -f .\containers\wetty\Dockerfile --progress=plain --no-cache
#0 building with "default" instance using docker driver

#1 [internal] load .dockerignore
#1 transferring context: 136B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 585B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/node:current-alpine
#3 DONE 0.4s

#4 [builder 1/6] FROM docker.io/library/node:current-alpine@sha256:1c411f88868d97e206a5fdb78cbcee49add59022ecf1f52d54f15e1d4518c5c2
#4 CACHED

#5 [stage-1 2/6] WORKDIR /usr/src/app
#5 CACHED

#6 [internal] load build context
#6 transferring context: 24.28kB 0.0s done
#6 DONE 0.1s

#7 [builder 2/6] RUN apk add -U build-base python3
#7 0.382 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#7 0.586 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#7 0.823 (1/34) Installing zstd-libs (1.5.5-r4)
#7 0.848 (2/34) Installing binutils (2.40-r7)
#7 0.963 (3/34) Installing libmagic (5.44-r4)
#7 0.995 (4/34) Installing file (5.44-r4)
#7 1.009 (5/34) Installing libgomp (12.2.1_git20220924-r10)
#7 1.031 (6/34) Installing libatomic (12.2.1_git20220924-r10)
#7 1.062 (7/34) Installing gmp (6.2.1-r3)
#7 1.085 (8/34) Installing isl26 (0.26-r1)
#7 1.129 (9/34) Installing mpfr4 (4.2.0-r3)
#7 1.156 (10/34) Installing mpc1 (1.3.1-r1)
#7 1.175 (11/34) Installing gcc (12.2.1_git20220924-r10)
#7 2.223 (12/34) Installing libstdc++-dev (12.2.1_git20220924-r10)
#7 2.547 (13/34) Installing musl-dev (1.2.4-r0)
#7 2.637 (14/34) Installing libc-dev (0.7.2-r5)
#7 2.654 (15/34) Installing g++ (12.2.1_git20220924-r10)
#7 3.004 (16/34) Installing make (4.4.1-r1)
#7 3.023 (17/34) Installing fortify-headers (1.1-r3)
#7 3.041 (18/34) Installing patch (2.7.6-r10)
#7 3.062 (19/34) Installing build-base (0.5-r3)
#7 3.081 (20/34) Installing libbz2 (1.0.8-r5)
#7 3.102 (21/34) Installing libexpat (2.5.0-r1)
#7 3.136 (22/34) Installing libffi (3.4.4-r2)
#7 3.151 (23/34) Installing gdbm (1.23-r1)
#7 3.170 (24/34) Installing xz-libs (5.4.3-r0)
#7 3.189 (25/34) Installing mpdecimal (2.5.1-r2)
#7 3.207 (26/34) Installing ncurses-terminfo-base (6.4_p20230506-r0)
#7 3.238 (27/34) Installing libncursesw (6.4_p20230506-r0)
#7 3.256 (28/34) Installing libpanelw (6.4_p20230506-r0)
#7 3.274 (29/34) Installing readline (8.2.1-r1)
#7 3.294 (30/34) Installing sqlite-libs (3.41.2-r2)
#7 3.326 (31/34) Installing python3 (3.11.4-r0)
#7 3.572 (32/34) Installing python3-pycache-pyc0 (3.11.4-r0)
#7 3.698 (33/34) Installing pyc (0.1-r0)
#7 3.712 (34/34) Installing python3-pyc (3.11.4-r0)
#7 3.730 Executing busybox-1.36.1-r0.trigger
#7 3.735 OK: 284 MiB in 51 packages
#7 DONE 3.9s

#8 [builder 3/6] WORKDIR /usr/src/app
#8 DONE 0.1s

#9 [builder 4/6] COPY . /usr/src/app
#9 DONE 0.1s

#10 [builder 5/6] RUN yarn install
#10 0.773 yarn install v1.22.19
#10 0.842 [1/5] Validating package.json...
#10 0.845 [2/5] Resolving packages...
#10 1.074 [3/5] Fetching packages...
#10 12.73 [4/5] Linking dependencies...
#10 17.46 [5/5] Building fresh packages...
#10 17.82 error /usr/src/app/node_modules/node-pty: Command failed.
#10 17.82 Exit code: 1
#10 17.82 Command: node scripts/install.js
#10 17.82 Arguments:
#10 17.82 Directory: /usr/src/app/node_modules/node-pty
#10 17.82 Output:
#10 17.82 node:events:490
#10 17.82       throw er; // Unhandled 'error' event
#10 17.82       ^
#10 17.82
#10 17.82 Error: spawn node-gyp ENOENT
#10 17.82     at ChildProcess._handle.onexit (node:internal/child_process:285:19)
#10 17.82     at onErrorNT (node:internal/child_process:483:16)
#10 17.82     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
#10 17.82 Emitted 'error' event on ChildProcess instance at:
#10 17.82     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
#10 17.82     at onErrorNT (node:internal/child_process:483:16)
#10 17.82     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
#10 17.82   errno: -2,
#10 17.82   code: 'ENOENT',
#10 17.82   syscall: 'spawn node-gyp',
#10 17.82   path: 'node-gyp',
#10 17.82   spawnargs: [ 'rebuild' ]
#10 17.82 }
#10 17.82
#10 17.82 Node.js v20.4.0
#10 17.82 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
#10 ERROR: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1
------
 > [builder 5/6] RUN yarn install:
17.82     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
17.82   errno: -2,
17.82   code: 'ENOENT',
17.82   syscall: 'spawn node-gyp',
17.82   path: 'node-gyp',
17.82   spawnargs: [ 'rebuild' ]
17.82 }
17.82
17.82 Node.js v20.4.0
17.82 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile:5
--------------------
   3 |     WORKDIR /usr/src/app
   4 |     COPY . /usr/src/app
   5 | >>> RUN yarn install
   6 |     RUN yarn build
   7 |
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1

```

After adding node-gyp, build is successful:
```
wetty on  fix-docker-build [?] is 📦 v2.6.0 via  v20.4.0 
❯ docker build . -f .\containers\wetty\Dockerfile --progress=plain --no-cache
#0 building with "default" instance using docker driver

#1 [internal] load .dockerignore
#1 transferring context: 136B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 615B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/node:current-alpine
#3 DONE 7.5s

#4 [builder 1/7] FROM docker.io/library/node:current-alpine@sha256:1c411f88868d97e206a5fdb78cbcee49add59022ecf1f52d54f15e1d4518c5c2
#4 CACHED

#5 [stage-1 2/6] WORKDIR /usr/src/app
#5 CACHED

#6 [internal] load build context
#6 transferring context: 29.56kB 0.0s done
#6 DONE 0.1s

#7 [builder 2/7] RUN apk add -U build-base python3
#7 0.335 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#7 0.533 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#7 0.764 (1/34) Installing zstd-libs (1.5.5-r4)
#7 0.792 (2/34) Installing binutils (2.40-r7)
#7 0.903 (3/34) Installing libmagic (5.44-r4)
#7 0.949 (4/34) Installing file (5.44-r4)
#7 0.964 (5/34) Installing libgomp (12.2.1_git20220924-r10)
#7 0.989 (6/34) Installing libatomic (12.2.1_git20220924-r10)
#7 1.008 (7/34) Installing gmp (6.2.1-r3)
#7 1.033 (8/34) Installing isl26 (0.26-r1)
#7 1.078 (9/34) Installing mpfr4 (4.2.0-r3)
#7 1.104 (10/34) Installing mpc1 (1.3.1-r1)
#7 1.136 (11/34) Installing gcc (12.2.1_git20220924-r10)
#7 2.117 (12/34) Installing libstdc++-dev (12.2.1_git20220924-r10)
#7 2.437 (13/34) Installing musl-dev (1.2.4-r0)
#7 2.551 (14/34) Installing libc-dev (0.7.2-r5)
#7 2.568 (15/34) Installing g++ (12.2.1_git20220924-r10)
#7 2.867 (16/34) Installing make (4.4.1-r1)
#7 2.887 (17/34) Installing fortify-headers (1.1-r3)
#7 2.904 (18/34) Installing patch (2.7.6-r10)
#7 2.939 (19/34) Installing build-base (0.5-r3)
#7 2.960 (20/34) Installing libbz2 (1.0.8-r5)
#7 2.981 (21/34) Installing libexpat (2.5.0-r1)
#7 3.001 (22/34) Installing libffi (3.4.4-r2)
#7 3.017 (23/34) Installing gdbm (1.23-r1)
#7 3.036 (24/34) Installing xz-libs (5.4.3-r0)
#7 3.059 (25/34) Installing mpdecimal (2.5.1-r2)
#7 3.099 (26/34) Installing ncurses-terminfo-base (6.4_p20230506-r0)
#7 3.117 (27/34) Installing libncursesw (6.4_p20230506-r0)
#7 3.144 (28/34) Installing libpanelw (6.4_p20230506-r0)
#7 3.174 (29/34) Installing readline (8.2.1-r1)
#7 3.196 (30/34) Installing sqlite-libs (3.41.2-r2)
#7 3.237 (31/34) Installing python3 (3.11.4-r0)
#7 3.485 (32/34) Installing python3-pycache-pyc0 (3.11.4-r0)
#7 3.637 (33/34) Installing pyc (0.1-r0)
#7 3.661 (34/34) Installing python3-pyc (3.11.4-r0)
#7 3.677 Executing busybox-1.36.1-r0.trigger
#7 3.683 OK: 284 MiB in 51 packages
#7 DONE 3.8s

#8 [builder 3/7] WORKDIR /usr/src/app
#8 DONE 0.1s

#9 [builder 4/7] COPY . /usr/src/app
#9 DONE 0.1s

#10 [builder 5/7] RUN yarn global add node-gyp
#10 0.703 yarn global v1.22.19
#10 0.752 [1/4] Resolving packages...
#10 1.652 [2/4] Fetching packages...
#10 2.653 [3/4] Linking dependencies...
#10 3.045 [4/4] Building fresh packages...
#10 3.054 success Installed "node-gyp@9.4.0" with binaries:
#10 3.054       - node-gyp
#10 3.056 Done in 2.36s.
#10 DONE 3.1s

#11 [builder 6/7] RUN yarn install
#11 0.645 yarn install v1.22.19
#11 0.714 [1/5] Validating package.json...
#11 0.717 [2/5] Resolving packages...
#11 0.932 [3/5] Fetching packages...
#11 11.52 [4/5] Linking dependencies...
#11 16.27 [5/5] Building fresh packages...
#11 20.53 Done in 19.89s.
#11 DONE 21.0s

#12 [builder 7/7] RUN yarn build
#12 0.654 yarn run v1.22.19
#12 0.701 $ snowpack build
#12 1.278 [04:56:28] [snowpack] ! building files...
#12 1.348 [04:56:28] [snowpack] ✔ files built. [0.07s]
#12 1.348 [04:56:28] [snowpack] ! building dependencies...
#12 2.639 [04:56:30] [sass] Command completed.
#12 4.344 [04:56:31] [tsc] Command completed.
#12 4.345 [04:56:31] [tsc] Command completed.
#12 4.690 [04:56:32] [esinstall] /usr/src/app/node_modules/file-type/index.js:1045:16 Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification
#12 5.320 [04:56:32] [snowpack] ✔ dependencies built. [3.97s]
#12 5.320 [04:56:32] [snowpack] ! writing to disk...
#12 5.346 [04:56:32] [snowpack] ✔ write complete. [0.03s]
#12 5.350 [04:56:32] [snowpack] ▶ Build Complete!
#12 5.373 Done in 4.72s.
#12 DONE 5.4s

#13 [stage-1 3/6] COPY --from=builder /usr/src/app/build /usr/src/app/build
#13 DONE 0.1s

#14 [stage-1 4/6] COPY --from=builder /usr/src/app/node_modules /usr/src/app/node_modules
#14 DONE 2.4s

#15 [stage-1 5/6] COPY package.json /usr/src/app
#15 DONE 0.1s

#16 [stage-1 6/6] RUN apk add -U coreutils openssh-client sshpass &&     mkdir ~/.ssh
#16 0.295 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#16 0.584 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#16 0.866 (1/12) Installing libacl (2.3.1-r3)
#16 0.880 (2/12) Installing libattr (2.5.1-r4)
#16 0.897 (3/12) Installing skalibs (2.13.1.1-r1)
#16 0.918 (4/12) Installing utmps-libs (0.1.2.1-r1)
#16 0.934 (5/12) Installing coreutils (9.3-r1)
#16 0.976 (6/12) Installing openssh-keygen (9.3_p1-r3)
#16 0.997 (7/12) Installing ncurses-terminfo-base (6.4_p20230506-r0)
#16 1.018 (8/12) Installing libncursesw (6.4_p20230506-r0)
#16 1.040 (9/12) Installing libedit (20221030.3.1-r1)
#16 1.059 (10/12) Installing openssh-client-common (9.3_p1-r3)
#16 1.108 (11/12) Installing openssh-client-default (9.3_p1-r3)
#16 1.137 (12/12) Installing sshpass (1.10-r0)
#16 1.157 Executing busybox-1.36.1-r0.trigger
#16 1.162 OK: 16 MiB in 29 packages
#16 DONE 1.2s

#17 exporting to image
#17 exporting layers
#17 exporting layers 2.4s done
#17 writing image sha256:3b59dc724a6eb06a32cf37b50cae32e05820445ac1819fda9a77e38a39d73763 done
#17 DONE 2.4s

What's Next?
  View summary of image vulnerabilities and recommendations → docker scout quickview


```

