### PR TITLE
Don't include sourcemaps when building for prod

### DIFF
--- a/build.js
+++ b/build.js
@@ -45,7 +45,7 @@ async function buildClient(watching){
         platform: 'browser',
         format: 'esm',
         minify: !watching,
-        sourcemap: !watching,
+        sourcemap: watching,
         plugins: [
             typechecker,
             sassPlugin({


### PR DESCRIPTION
We shouldn't build sourcemaps unless we are building in dev mode and thus watching for changes