### PR TITLE
fix(docker): resolve native module build failures in production dependencies

### DIFF
--- a/containers/wetty/Dockerfile
+++ b/containers/wetty/Dockerfile
@@ -1,29 +1,37 @@
-FROM node:current-alpine as base
-RUN apk add -U build-base python3
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-RUN npx pnpm i -g pnpm@latest
+# ---------- Base image ----------
+FROM node:20-alpine as base
+RUN apk add -U build-base python3 py3-setuptools make g++ git
 WORKDIR /usr/src/app
+
+# Install pnpm globally
+RUN npm install -g pnpm@latest
+
 COPY . /usr/src/app
 
+# ---------- Production dependencies ----------
 FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store pnpm install --prod --frozen-lockfile --ignore-scripts
+# Rebuild only the native modules we need
+RUN cd node_modules/node-pty && npm run install && cd ../..
+RUN cd node_modules/.pnpm/gc-stats@1.4.1/node_modules/gc-stats && npm run install
 
+# ---------- Build stage ----------
 FROM base AS build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM node:current-alpine
+# ---------- Final runtime image ----------
+FROM base
 LABEL maintainer="butlerx@notthe.cloud"
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
-EXPOSE 3000
+
 COPY --from=prod-deps /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --from=build /usr/src/app/build /usr/src/app/build
 COPY package.json /usr/src/app
-RUN apk add -U coreutils openssh-client sshpass && \
-    mkdir ~/.ssh
 
-EXPOSE 8000
-CMD [ "pnpm", "start" ]
+RUN apk add -U coreutils openssh-client sshpass && \
+    mkdir -p ~/.ssh
+
+EXPOSE 3000
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Problem
fix #562 

<img width="1109" height="494" alt="image" src="https://github.com/user-attachments/assets/7fa0d7ec-4783-4bc1-a5a8-608a4d200bb7" />


The Docker build was failing with multiple errors:
1. `ModuleNotFoundError: No module named 'distutils'` when building native modules
2. `husky: not found` error during production dependency installation
3. Native modules (node-pty, gc-stats) failing to compile

## Solution

### Changes Made
- **Added `py3-setuptools`**: Python 3.12+ removed the `distutils` module, which is required by `node-gyp` for building native modules. Adding `py3-setuptools` provides the necessary compatibility layer.

- **Used `--ignore-scripts` flag**: Skip all install scripts (including the `prepare` script that runs `husky install`) during production dependency installation, since husky is a dev dependency.

- **Manual native module rebuilds**: After skipping install scripts, manually rebuild only the required native modules:
  - `node-pty`: Required for terminal emulation
  - `gc-stats`: Required for garbage collection statistics

### Testing
- ✅ Docker build completes successfully
- ✅ Container starts and runs wetty application on port 3000
- ✅ All native modules compile correctly
- ✅ No dev dependencies required in production build

## Before
```
ERROR [prod-deps 1/1] RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store pnpm install --prod --frozen
ModuleNotFoundError: No module named 'distutils'
```

## After
```
wetty-web-1 | [INFO] Starting Server
wetty-web-1 | Server started: [http://0.0.0.0:3000](https://mysterious-ghost-6w7p9grq6gqcxqv.github.dev/?editSessionId=dbc41993-8cf2-4f1f-8481-9e75f1b75ace&continueOn=1)
```