### PR TITLE
Prevent socket disconnects when terminal is in a background tab

### DIFF
--- a/src/client/wetty.ts
+++ b/src/client/wetty.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 import '../assets/scss/styles.scss';
 
-import { disconnect } from './wetty/disconnect';
+import { disconnect, showReconnecting, hideOverlay } from './wetty/disconnect';
 import { overlay } from './wetty/disconnect/elements';
 import { verifyPrompt } from './wetty/disconnect/verify';
 import { FileDownloader } from './wetty/download';
@@ -66,8 +66,22 @@ socket.on('connect', () => {
       term.resizeTerm();
     })
     .on('logout', disconnect)
-    .on('disconnect', disconnect)
+    .on('disconnect', (reason: string) => {
+      if (socket.active) {
+        showReconnecting();
+      } else {
+        disconnect(reason);
+      }
+    })
     .on('error', (err: string | null) => {
       if (err) disconnect(err);
     });
+});
+
+socket.io.on('reconnect', () => {
+  hideOverlay();
+});
+
+socket.io.on('reconnect_failed', () => {
+  disconnect('Connection lost. Please reconnect.');
 });

--- a/src/client/wetty/disconnect.ts
+++ b/src/client/wetty/disconnect.ts
@@ -9,3 +9,15 @@ export function disconnect(reason: string): void {
   if (!_.isUndefined(reason) && !_.isNull(msg)) msg.innerHTML = reason;
   window.removeEventListener('beforeunload', verifyPrompt, false);
 }
+
+export function showReconnecting(): void {
+  if (_.isNull(overlay)) return;
+  overlay.style.display = 'block';
+  const msg = document.getElementById('msg');
+  if (!_.isNull(msg)) msg.innerHTML = 'Reconnecting...';
+}
+
+export function hideOverlay(): void {
+  if (_.isNull(overlay)) return;
+  overlay.style.display = 'none';
+}

--- a/src/client/wetty/socket.ts
+++ b/src/client/wetty/socket.ts
@@ -5,4 +5,8 @@ export const trim = (str: string): string => str.replace(/\/*$/, '');
 const socketBase = trim(window.location.pathname).replace(/ssh\/[^/]+$/, '');
 export const socket = io(window.location.origin, {
   path: `${trim(socketBase)}/socket.io`,
+  reconnection: true,
+  reconnectionAttempts: 10,
+  reconnectionDelay: 1000,
+  reconnectionDelayMax: 30000,
 });

--- a/src/server/socketServer/socket.ts
+++ b/src/server/socketServer/socket.ts
@@ -38,6 +38,6 @@ export const listen = (
   return new Server(server, {
     path: `${path}/socket.io`,
     pingInterval: 25000,
-    pingTimeout: 60000,
+    pingTimeout: 300000,
   });
 }

--- a/src/server/socketServer/socket.ts
+++ b/src/server/socketServer/socket.ts
@@ -37,7 +37,7 @@ export const listen = (
   // Create Socket.IO server
   return new Server(server, {
     path: `${path}/socket.io`,
-    pingInterval: 3000,
-    pingTimeout: 7000,
+    pingInterval: 25000,
+    pingTimeout: 60000,
   });
 }


### PR DESCRIPTION
Increases Socket.IO heartbeat tolerance and adds automatic reconnection to prevent Wetty terminals from disconnecting when embedded in background browser tabs or hidden iframes, where Chrome aggressively throttles JavaScript timers.

## Changes
- Increase server-side `pingInterval` from 3s to 25s and `pingTimeout` from 7s to 300s (5 minutes) to survive background tab timer throttling
- Enable client-side automatic reconnection with up to 10 attempts and exponential backoff (1s–30s)
- Show a "Reconnecting..." overlay during reconnection attempts instead of immediately displaying the disconnect screen
- Hide the overlay automatically on successful reconnect

## Notes
- The previous `pingTimeout` of 7s was far too aggressive — Chrome throttles background tab timers to ~1 execution/minute, easily causing missed pongs
- The 300s `pingTimeout` adds no downside; it only means the server is more patient before declaring a client dead