### PR TITLE
fix: --command flag now works for non-root users

### DIFF
--- a/src/server/command.ts
+++ b/src/server/command.ts
@@ -9,6 +9,9 @@ const localhost = (host: string): boolean =>
   process.getuid?.() === 0 &&
   (host === 'localhost' || host === '0.0.0.0' || host === '127.0.0.1');
 
+const isLocalHost = (host: string): boolean =>
+  host === 'localhost' || host === '0.0.0.0' || host === '127.0.0.1';
+
 const urlArgs = (
   referer: string | undefined,
   {
@@ -59,6 +62,10 @@ export async function getCommand(
       conn: { remoteAddress },
     },
   } = socket;
+
+  if (!forcessh && command !== 'login' && isLocalHost(host)) {
+    return loginOptions(command, remoteAddress);
+  }
 
   if (!forcessh && localhost(host)) {
     return loginOptions(command, remoteAddress);


### PR DESCRIPTION
## Summary

Running `wetty --command /bin/bash` as non-root would silently SSH to localhost instead of executing the command directly. This fixes the behavior.

## Problem

The `localhost()` check required `process.getuid() === 0`, so custom commands were only executed locally when running as root. Non-root users always fell through to SSH, even when no remote host was specified.

## Fix

- Added `isLocalHost()` helper — same hostname check but without the root requirement
- Added a new code path: when `command !== 'login'` (custom command) and host is local, run directly regardless of uid

## Behavior

| Command | Result |
|---------|--------|
| `wetty --command /bin/bash` | Runs bash locally (fixed!) |
| `wetty --command /bin/bash --ssh-host H` | SSH + bash on remote |
| `wetty --command /bin/bash --force-ssh` | SSH + bash on localhost |
| `wetty` (non-root, no flags) | SSH to localhost (unchanged) |
| `wetty` (root, no flags) | /bin/login (unchanged) |

## Test plan

- [x] `pnpm build` and `pnpm test` pass