### PR TITLE
fix: resolve Docker build and esbuild race condition

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ dist
 build
 docs
 Dockerfile
+*.tsbuildinfo

--- a/build.js
+++ b/build.js
@@ -78,7 +78,7 @@ async function buildClient(watching) {
     const buildCtx = await esbuild.context(esConf);
     await buildCtx.watch();
   } else {
-    esbuild.build(esConf);
+    await esbuild.build(esConf);
   }
 }
 
@@ -87,7 +87,7 @@ async function buildClient(watching) {
 async function buildServer(watching) {
   const tscArgs = ['tsc', '-p', 'tsconfig.node.json'];
   if (watching) tscArgs.push('--watch', '--preserveWatchOutput');
-  const [_tsc, tscDone] = cmd('pnpm', tscArgs);
+  const [_tsc, tscDone] = cmd('npx', tscArgs);
   if (!watching) await tscDone;
 }
 


### PR DESCRIPTION
## Summary

Three fixes for the build process that were causing blank Docker images.

## Fixes

1. **`await esbuild.build()`** — In non-watch mode the esbuild promise was not awaited, causing a race condition with the tsc server compilation step.

2. **`npx tsc` instead of `pnpm tsc`** — `pnpm tsc` may fail to locate the typescript binary in some environments. `npx tsc` uses the local node_modules/.bin resolution reliably.

3. **Exclude `*.tsbuildinfo` in `.dockerignore`** — TypeScript incremental build cache files were copied into the Docker build context, causing tsc to skip compilation entirely. The resulting Docker images were missing all server JavaScript files.

## Test plan

- [x] `pnpm build && pnpm test` pass
- [x] Docker build produces `build/main.js` and other server files