### PR TITLE
feat(client): sync browser tab title with terminal OSC 0/2

### DIFF
--- a/src/client/wetty/disconnect.ts
+++ b/src/client/wetty/disconnect.ts
@@ -1,10 +1,12 @@
 import { overlay } from './disconnect/elements';
 import { verifyPrompt } from './disconnect/verify';
+import { resetTitle } from './title';
 
 export function disconnect(reason?: string): void {
+  window.removeEventListener('beforeunload', verifyPrompt, false);
+  resetTitle();
   if (overlay === null) return;
   overlay.style.display = 'block';
   const msg = document.getElementById('msg');
   if (msg !== null) msg.textContent = reason ?? 'Session ended';
-  window.removeEventListener('beforeunload', verifyPrompt, false);
 }

--- a/src/client/wetty/term.ts
+++ b/src/client/wetty/term.ts
@@ -7,6 +7,7 @@ import { Terminal } from '@xterm/xterm';
 import { terminal as termElement } from './disconnect/elements';
 import { configureTerm } from './term/configuration';
 import { loadOptions } from './term/load';
+import { setTitle } from './title';
 import type { Options } from './term/options';
 import type { Socket } from 'socket.io-client';
 
@@ -35,6 +36,7 @@ export class Term extends Terminal {
         // WebGL not available — DOM renderer will be used
       }
     }
+    this.onTitleChange(setTitle);
   }
 
   resizeTerm(): void {

--- a/src/client/wetty/title.ts
+++ b/src/client/wetty/title.ts
@@ -1,0 +1,9 @@
+const defaultTitle = document.title;
+
+export const setTitle = (t: string): void => {
+  document.title = t || defaultTitle;
+};
+
+export const resetTitle = (): void => {
+  document.title = defaultTitle;
+};


### PR DESCRIPTION
**TL;DR;**

Add a small title module that captures the page's default title at load and exposes setTitle/resetTitle. Wire xterm.js's onTitleChange into setTitle so escape sequences from the remote shell (OSC 0 and OSC 2 — set window title) drive the browser tab title. On socket disconnect, restore the default title so a stale shell title doesn't linger.

**What**

Make the browser tab title follow the terminal's title, the way a native terminal emulator does. When the remote shell emits an OSC 0 / OSC 2 set window title sequence (via PROMPT_COMMAND, ssh, vim, tmux, …), the browser tab reflects it. On disconnect the original page title is restored so a stale shell title doesn't linger.

**How**
- New src/client/wetty/title.ts — captures the default title and exposes setTitle / resetTitle. 
- term.ts — wires xterm.js's built-in onTitleChange into setTitle.
- disconnect.ts — calls resetTitle() on session end.

**Testing:** 
pnpm lint clean · pnpm build ok · pnpm test 17/17 · manually verified with printf '\033]0;hello\007' and on disconnect. 

Done