### PR TITLE
fix(server): prevent macOS PTY exhaustion

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fresh": "^0.5.2",
     "helmet": "^8.2.0",
     "json5": "^2.2.3",
-    "node-pty": "^1.1.0",
+    "node-pty": "1.2.0-beta.14",
     "parseurl": "^1.3.3",
     "prom-client": "^15.1.3",
     "response-time": "^2.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: 1.2.0-beta.14
+        version: 1.2.0-beta.14
       parseurl:
         specifier: ^1.3.3
         version: 1.3.3
@@ -2663,8 +2663,8 @@ packages:
       encoding:
         optional: true
 
-  node-pty@1.1.0:
-    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+  node-pty@1.2.0-beta.14:
+    resolution: {integrity: sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA==}
 
   nodeify@1.0.1:
     resolution: {integrity: sha512-n7C2NyEze8GCo/z73KdbjRsBiLbv6eBn1FxwYKQ23IqGo7pQY3mhQan61Sv7eEDJCiyUjTVrVkXTzJCo1dW7Aw==}
@@ -6487,7 +6487,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-pty@1.1.0:
+  node-pty@1.2.0-beta.14:
     dependencies:
       node-addon-api: 7.1.1
 


### PR DESCRIPTION
## Summary

- upgrade `node-pty` from `1.1.0` to `1.2.0-beta.14`
- pin the beta version until a stable release contains the macOS descriptor-leak fixes
- update the pnpm lockfile

## Problem

On macOS, a long-running WeTTY server leaked one `/dev/ptmx` descriptor for each terminal session. Once the system-wide PTY limit (511 on the affected machine) was exhausted, new sessions immediately failed with:

```
PTY allocation request failed on channel 0
```

The WeTTY HTTP server and proxy continued to respond, which made the failure look like an SSH or WebSocket problem.

`node-pty` 1.2.0 beta releases include the upstream fixes for the `/dev/ptmx` leak and the macOS kqueue descriptor leak:

- microsoft/node-pty#882
- microsoft/node-pty#931

## Verification

- `pnpm test` — 17 passing
- `pnpm build` — completes (the existing unrelated `download.spec.ts` type-check warnings remain)
- 20 sequential WebSocket login/disconnect cycles through the authenticated proxy
- WeTTY character-device descriptor count remained at 2 before and after the stress test
- SSH PTY allocation and both backend/proxy HTTP endpoints were verified successfully
