### PR TITLE
feat: make Socket.IO ping interval/timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Options:
   --allow-remote-command  Allow wetty to use the command and path
                           params in a url as command and working
                           directory on ssh host                         [boolean]
+  --ping-interval         Milliseconds between Socket.IO heartbeat
+                          pings sent to the client                       [number]
+  --ping-timeout          Milliseconds to wait for a Socket.IO
+                          heartbeat pong before considering the
+                          connection dead                                [number]
   --log-level             set log level of wetty server                  [string]
 ```
 

--- a/conf/config.json5
+++ b/conf/config.json5
@@ -18,6 +18,8 @@
     title:        'WeTTY - The Web Terminal Emulator', // Page title
     // socket:    '/tmp/wetty.sock',                   // Unix socket to listen on (mutually exclusive with host/port)
     // allowIframe: false,                             // Allow WeTTY to be embedded in an iframe
+    // pingInterval: 3000,                             // Milliseconds between socket.io heartbeat pings
+    // pingTimeout:  7000,                             // Milliseconds to wait for a pong before dropping the connection
   },
 
   forceSSH: false,  // Force sshing to local machine over login if running as root

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,31 +17,33 @@ Starts WeTTY Server
 **Kind**: inner property of [`WeTTy`](#module_WeTTy)  
 **Returns**: `Promise` - Promise resolves once server is running
 
-| Param                    | Type      | Default                               | Description                                                                                                            |
-| :----------------------- | --------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| [ssh]                    | `Object`  |                                       | SSH settings                                                                                                           |
-| [ssh.user]               | `string`  | `"''"`                                | default user for ssh                                                                                                   |
-| [ssh.host]               | `string`  | `"localhost"`                         | machine to ssh too                                                                                                     |
-| [ssh.auth]               | `string`  | `"password"`                          | authtype to use                                                                                                        |
-| [ssh.port]               | `number`  | `22`                                  | port to connect to over ssh                                                                                            |
-| [ssh.pass]               | `string`  |                                       | Optional param of a password to use for ssh                                                                            |
-| [ssh.key]                | `string`  |                                       | path to an optional client private key (connection will be password-less and insecure!)                                |
-| [ssh.config]             | `string`  |                                       | Specifies an alternative ssh configuration file. For further details see "-F" option in ssh(1)                         |
-| [ssh.knownHosts]         | `string`  | `"/dev/null"`                         | path to known hosts file                                                                                               |
-| [ssh.allowRemoteHosts]   | `boolean` | `false`                               | Allow using the host and port params in a url as ssh destination                                                       |
-| [ssh.allowRemoteCommand] | `boolean` | `false`                               | Allow using the command and path params in a url as command and working directory on ssh host                          |
-| [serverConf]             | `Object`  |                                       | Server settings                                                                                                        |
-| [serverConf.base]        | `string`  | `'/'`                                 | URL base to serve resources from                                                                                       |
-| [serverConf.port]        | `number`  | `3000`                                | Port to run server on                                                                                                  |
-| [serverConf.host]        | `string`  | `'0.0.0.0'`                           | Host address for server                                                                                                |
-| [serverConf.socket]      | `string`  | `false`                               | Unix socket path to listen on (mutually exclusive with host/port)                                                      |
-| [serverConf.title]       | `string`  | `'WeTTY - The Web Terminal Emulator'` | Title of the server                                                                                                    |
-| [serverConf.allowIframe] | `boolean` | `false`                               | Allow WeTTY to be embedded in an iframe                                                                                |
-| [command]                | `string`  | `"'login'"`                           | The command to execute. If running as root and no host specified this will be login if a host is specified will be ssh |
-| [forcessh]               | `boolean` | `false`                               | Connecting through ssh even if running as root                                                                         |
-| [ssl]                    | `Object`  |                                       | SSL settings                                                                                                           |
-| [ssl.key]                | `string`  |                                       | Path to ssl key                                                                                                        |
-| [ssl.cert]               | `string`  |                                       | Path to ssl cert                                                                                                       |
+| Param                     | Type      | Default                               | Description                                                                                                            |
+| :------------------------ | --------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [ssh]                     | `Object`  |                                       | SSH settings                                                                                                           |
+| [ssh.user]                | `string`  | `"''"`                                | default user for ssh                                                                                                   |
+| [ssh.host]                | `string`  | `"localhost"`                         | machine to ssh too                                                                                                     |
+| [ssh.auth]                | `string`  | `"password"`                          | authtype to use                                                                                                        |
+| [ssh.port]                | `number`  | `22`                                  | port to connect to over ssh                                                                                            |
+| [ssh.pass]                | `string`  |                                       | Optional param of a password to use for ssh                                                                            |
+| [ssh.key]                 | `string`  |                                       | path to an optional client private key (connection will be password-less and insecure!)                                |
+| [ssh.config]              | `string`  |                                       | Specifies an alternative ssh configuration file. For further details see "-F" option in ssh(1)                         |
+| [ssh.knownHosts]          | `string`  | `"/dev/null"`                         | path to known hosts file                                                                                               |
+| [ssh.allowRemoteHosts]    | `boolean` | `false`                               | Allow using the host and port params in a url as ssh destination                                                       |
+| [ssh.allowRemoteCommand]  | `boolean` | `false`                               | Allow using the command and path params in a url as command and working directory on ssh host                          |
+| [serverConf]              | `Object`  |                                       | Server settings                                                                                                        |
+| [serverConf.base]         | `string`  | `'/'`                                 | URL base to serve resources from                                                                                       |
+| [serverConf.port]         | `number`  | `3000`                                | Port to run server on                                                                                                  |
+| [serverConf.host]         | `string`  | `'0.0.0.0'`                           | Host address for server                                                                                                |
+| [serverConf.socket]       | `string`  | `false`                               | Unix socket path to listen on (mutually exclusive with host/port)                                                      |
+| [serverConf.title]        | `string`  | `'WeTTY - The Web Terminal Emulator'` | Title of the server                                                                                                    |
+| [serverConf.allowIframe]  | `boolean` | `false`                               | Allow WeTTY to be embedded in an iframe                                                                                |
+| [serverConf.pingInterval] | `number`  | `3000`                                | Milliseconds between socket.io heartbeat pings                                                                         |
+| [serverConf.pingTimeout]  | `number`  | `7000`                                | Milliseconds to wait for a heartbeat pong before dropping the connection                                               |
+| [command]                 | `string`  | `"'login'"`                           | The command to execute. If running as root and no host specified this will be login if a host is specified will be ssh |
+| [forcessh]                | `boolean` | `false`                               | Connecting through ssh even if running as root                                                                         |
+| [ssl]                     | `Object`  |                                       | SSL settings                                                                                                           |
+| [ssl.key]                 | `string`  |                                       | Path to ssl key                                                                                                        |
+| [ssl.cert]                | `string`  |                                       | Path to ssl cert                                                                                                       |
 
 ### "connection"
 

--- a/docs/atoz.md
+++ b/docs/atoz.md
@@ -368,7 +368,9 @@ pass validation.
         "port": 3000, // Port to listen on
         "host": "0.0.0.0", // listen on all interfaces or can be 127.0.0.1 with nginx
         "title": "WeTTY - The Web Terminal Emulator", // Page title
-        "allowIframe": false // Allow WeTTY to be embedded in an iframe
+        "allowIframe": false, // Allow WeTTY to be embedded in an iframe
+        "pingInterval": 3000, // Milliseconds between Socket.IO heartbeat pings
+        "pingTimeout": 7000 // Milliseconds to wait for a pong before disconnecting
     },
     "forceSSH": false, // Force sshing to local machine over login if running as root
     "command": "login", // Command to run on server. Login will use ssh if connecting to different server
@@ -405,6 +407,8 @@ KNOWNHOSTS
 FORCESSH
 COMMAND
 ALLOWIFRAME
+PINGINTERVAL
+PINGTIMEOUT
 ```
 
 These can be used in the following way

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -58,6 +58,23 @@ By default WeTTY does not allow the `command` and `path` URL parameters to
 specify the command and working directory on the SSH host. To enable this, use
 the `--allow-remote-command` flag.
 
+## Socket.IO Ping Interval / Timeout
+
+WeTTY's browser terminal rides on a Socket.IO connection, kept alive with a
+heartbeat: the server pings the client every `--ping-interval` milliseconds
+(default `3000`) and expects a pong back within `--ping-timeout` milliseconds
+(default `7000`), or it closes the transport (shown to the user as a "transport
+close" error requiring reconnect).
+
+These defaults are tight compared to Socket.IO's own defaults (25000/20000). On
+a high-latency or lossy network path, a single delayed pong can exceed the 7
+second timeout and force a reconnect even though the underlying connection is
+otherwise healthy. If you see frequent "transport close" errors, try raising
+both, e.g. `--ping-interval 25000 --ping-timeout 20000`.
+
+Both flags also accept the `PINGINTERVAL` and `PINGTIMEOUT` environment
+variables.
+
 ## Log Level
 
 You can set the log level of the WeTTY server using the `--log-level` flag.

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,16 @@ const yargsInstance = yargs(hideBin(process.argv))
       'Allow WeTTY to be embedded in an iframe, defaults to allowing same origin',
     type: 'boolean',
   })
+  .option('ping-interval', {
+    description:
+      'Milliseconds between Socket.IO heartbeat pings sent to the client',
+    type: 'number',
+  })
+  .option('ping-timeout', {
+    description:
+      'Milliseconds to wait for a Socket.IO heartbeat pong before considering the connection dead. Raise this on high-latency or lossy links to avoid spurious "transport close" disconnects',
+    type: 'number',
+  })
   .option('allow-remote-hosts', {
     description:
       'Allow WeTTY to use the `host` and `port` params in a url as ssh destination',

--- a/src/server/socketServer.ts
+++ b/src/server/socketServer.ts
@@ -15,7 +15,16 @@ import type SocketIO from 'socket.io';
 
 export async function server(
   app: Express,
-  { base, port, host, title, allowIframe, socket }: Server,
+  {
+    base,
+    port,
+    host,
+    title,
+    allowIframe,
+    socket,
+    pingInterval,
+    pingTimeout,
+  }: Server,
   ssl?: SSL,
 ): Promise<SocketIO.Server> {
   const basePath = trim(base);
@@ -51,5 +60,14 @@ export async function server(
 
   const sslBuffer: SSLBuffer = await loadSSL(ssl);
 
-  return listen(app, host, port, basePath, sslBuffer, socket);
+  return listen(
+    app,
+    host,
+    port,
+    basePath,
+    sslBuffer,
+    socket,
+    pingInterval,
+    pingTimeout,
+  );
 }

--- a/src/server/socketServer/socket.ts
+++ b/src/server/socketServer/socket.ts
@@ -2,9 +2,43 @@ import http from 'http';
 import https from 'https';
 import { Server } from 'socket.io';
 
+import {
+  defaultPingInterval,
+  defaultPingTimeout,
+  positiveIntOr,
+} from '../../shared/defaults.js';
 import { logger } from '../../shared/logger.js';
 import type { SSLBuffer } from '../../shared/interfaces.js';
 import type express from 'express';
+
+/**
+ * Resolve a socket.io heartbeat value, warning when an unusable one is dropped
+ *
+ * socket.io turns a `NaN` or non positive interval into a 1ms timer, which
+ * pings in a tight loop and disconnects the client, so bad input falls back to
+ * the default rather than reaching the server options
+ *
+ * @param value - configured value, if any
+ * @param fallback - default to use when `value` is unusable
+ * @param option - option name, for the warning
+ * @returns a usable heartbeat value in milliseconds
+ *
+ */
+const heartbeat = (
+  value: number | undefined,
+  fallback: number,
+  option: string,
+): number => {
+  const resolved = positiveIntOr(value, fallback);
+  if (value !== undefined && resolved !== value) {
+    logger().warn('Ignoring invalid heartbeat value, using default', {
+      option,
+      value,
+      default: fallback,
+    });
+  }
+  return resolved;
+};
 
 export const listen = (
   app: express.Express,
@@ -13,6 +47,8 @@ export const listen = (
   path: string,
   { key, cert }: SSLBuffer,
   socket?: string | boolean,
+  pingInterval?: number,
+  pingTimeout?: number,
 ): Server => {
   // Create the base HTTP/HTTPS server
   const server =
@@ -37,7 +73,7 @@ export const listen = (
   // Create Socket.IO server
   return new Server(server, {
     path: `${path}/socket.io`,
-    pingInterval: 3000,
-    pingTimeout: 7000,
+    pingInterval: heartbeat(pingInterval, defaultPingInterval, 'pingInterval'),
+    pingTimeout: heartbeat(pingTimeout, defaultPingTimeout, 'pingTimeout'),
   });
 };

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -153,6 +153,8 @@ export function mergeCliConf(opts: Arguments, config: Config): Config {
       port: opts.port,
       title: opts.title,
       allowIframe: opts['allow-iframe'],
+      pingInterval: opts['ping-interval'],
+      pingTimeout: opts['ping-timeout'],
     } as Record<string, confValue>) as Server,
     command:
       opts.command === undefined || typeof opts.command !== 'string'

--- a/src/shared/defaults.spec.ts
+++ b/src/shared/defaults.spec.ts
@@ -1,0 +1,41 @@
+import 'mocha';
+import { expect } from 'chai';
+import { positiveIntOr } from './defaults';
+
+describe('positiveIntOr should never yield a value socket.io cannot use', () => {
+  it('should parse a numeric string', () => {
+    expect(positiveIntOr('25000', 3000)).to.equal(25000);
+  });
+
+  it('should pass a number through', () => {
+    expect(positiveIntOr(25000, 3000)).to.equal(25000);
+  });
+
+  it('should fall back when undefined', () => {
+    expect(positiveIntOr(undefined, 3000)).to.equal(3000);
+  });
+
+  it('should fall back on an empty string', () => {
+    expect(positiveIntOr('', 3000)).to.equal(3000);
+  });
+
+  it('should fall back on a non numeric string', () => {
+    expect(positiveIntOr('abc', 3000)).to.equal(3000);
+  });
+
+  it('should fall back on NaN', () => {
+    expect(positiveIntOr(NaN, 3000)).to.equal(3000);
+  });
+
+  it('should fall back on zero', () => {
+    expect(positiveIntOr(0, 3000)).to.equal(3000);
+  });
+
+  it('should fall back on a negative value', () => {
+    expect(positiveIntOr(-1, 3000)).to.equal(3000);
+  });
+
+  it('should fall back on infinity', () => {
+    expect(positiveIntOr(Infinity, 3000)).to.equal(3000);
+  });
+});

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -14,6 +14,33 @@ export const sshDefault: SSH = {
   config: process.env.SSHCONFIG ?? undefined,
 };
 
+/**
+ * Resolve a positive integer from an environment variable or config value
+ *
+ * Falls back when the value is missing, empty, non numeric or out of range, so
+ * a mistyped `PINGINTERVAL=` can never reach socket.io as `NaN`
+ *
+ * @param value - raw value to parse
+ * @param fallback - value to use when `value` is unusable
+ * @returns a positive integer
+ *
+ */
+export const positiveIntOr = (
+  value: string | number | undefined,
+  fallback: number,
+): number => {
+  const parsed = typeof value === 'string' ? parseInt(value, 10) : value;
+  return parsed !== undefined && Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : fallback;
+};
+
+export const defaultPingInterval = positiveIntOr(
+  process.env.PINGINTERVAL,
+  3000,
+);
+export const defaultPingTimeout = positiveIntOr(process.env.PINGTIMEOUT, 7000);
+
 export const serverDefault: Server = {
   base: process.env.BASE ?? '/',
   port: parseInt(process.env.PORT ?? '3000', 10),
@@ -21,6 +48,8 @@ export const serverDefault: Server = {
   socket: false,
   title: process.env.TITLE ?? 'WeTTY - The Web Terminal Emulator',
   allowIframe: process.env.ALLOWIFRAME === 'true',
+  pingInterval: defaultPingInterval,
+  pingTimeout: defaultPingTimeout,
 };
 
 export const forceSSHDefault = process.env.FORCESSH === 'true';

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -25,13 +25,15 @@ export interface SSLBuffer {
 }
 
 export interface Server {
-  [s: string]: string | number | boolean;
+  [s: string]: string | number | boolean | undefined;
   port: number;
   host: string;
   socket: string | boolean;
   title: string;
   base: string;
   allowIframe: boolean;
+  pingInterval?: number;
+  pingTimeout?: number;
 }
 
 export interface Config {


### PR DESCRIPTION
**TL;DR:**
The Socket.IO heartbeat is hardcoded to a 3s ping interval and 7s pong timeout,
much tighter than Socket.IO's own defaults (25s/20s). On a high-latency or lossy
path a single delayed pong trips the timeout and the session dies with
"transport close". This adds `--ping-interval` / `--ping-timeout` (plus
`PINGINTERVAL` / `PINGTIMEOUT` env vars and JSON5 config support), defaulting to
the current 3000/7000 so nothing changes unless explicitly set.

**Why:**
`new Server(...)` in `socketServer/socket.ts` passes `pingInterval: 3000,
pingTimeout: 7000`. Those are aggressive enough that a healthy-but-slow
connection gets torn down: the client only has to be 7 seconds late with one
pong. On a constrained network this produces a reconnect loop every few minutes,
which is indistinguishable from a broken server to the end user. There is
currently no way to relax it short of patching and rebuilding.

**What:**
- `--ping-interval` — milliseconds between heartbeat pings (default `3000`)
- `--ping-timeout` — milliseconds to wait for a pong before dropping the
  connection (default `7000`)
- Both also settable via `PINGINTERVAL` / `PINGTIMEOUT` env vars, and via the
  `server` block of a JSON5 config file.

**How:**
- `main.ts` — two new yargs options.
- `shared/defaults.ts` — a small `positiveIntOr` helper resolves the env vars,
  falling back to the existing 3000/7000 literals.
- `shared/interfaces.ts` + `shared/config.ts` — carried on the `Server`
  interface and merged through the existing `mergeCliConf` path, so JSON5
  config support comes for free and an unset flag correctly falls through to
  the env var rather than clobbering it with `undefined`.
- `socketServer.ts` → `socketServer/socket.ts` — threaded to the Socket.IO
  `Server` constructor, replacing the hardcoded literals. The `listen()`
  parameters are optional, so existing callers are unaffected.

**Invalid values can't reach socket.io.** This turned out to matter more than
expected: `parseInt('', 10)` and `parseInt('abc', 10)` are `NaN`, and `??` only
fires on `undefined`, so a compose file with `PINGINTERVAL: ${PINGINTERVAL}` and
the variable unset would hand socket.io `NaN`. engine.io coerces that to a **1ms
timer** — the server pings in a tight loop and drops the client immediately,
while the handshake advertises `pingInterval: null`. That is a worse version of
the exact bug this flag exists to fix, from a typo, with no error. Empty, non
numeric, zero and negative values now fall back to the defaults; a bad value
arriving from a flag or config file also logs a warning.

**Backwards compatibility:** defaults are unchanged. With no flags, no env vars
and no config, the handshake still reports 3000/7000 exactly as before. The two
new keys are optional on the `Server` interface, so existing TypeScript
consumers that build a `Server` literal keep compiling; this needed `| undefined`
on that interface's index signature, matching how `SSH` already declares its own
optional members.

**Testing:** `pnpm lint` clean · `pnpm build` ok · `pnpm test` 26/26 (9 new) ·
`tsc -p tsconfig.node.json --noEmit` clean · `commitlint` clean.

Verified end to end by building `containers/wetty/Dockerfile` from this branch
and reading the values back out of the live Socket.IO handshake
(`/socket.io/?EIO=4&transport=polling`):

| configuration | handshake reports |
| --- | --- |
| none (defaults) | `3000` / `7000` — unchanged |
| `PINGINTERVAL=25000 PINGTIMEOUT=20000` | `25000` / `20000` |
| `--ping-interval 25000 --ping-timeout 20000` | `25000` / `20000` |
| both, flags `9000`/`8000` over env `25000`/`20000` | `9000` / `8000` — flags win |
| `PINGINTERVAL=abc` or `PINGINTERVAL=` | `3000` — falls back, was `null` |

It has also been running on a Raspberry Pi deployment behind a reverse proxy at
25000/20000 for the past several days, accessed over exactly the kind of
high-latency link that triggered this, and it is substantially more stable than
the 3000/7000 build it replaced.

**Docs:** flag list in `README.md`; a new section in `docs/flags.md` explaining
the tradeoff and suggesting 25000/20000 as a starting point for lossy links;
`docs/atoz.md` env var list and JSON5 example; the `serverConf` table in
`docs/API.md`; and the shipped `conf/config.json5` sample. The `docs/API.md`
diff looks large only because the new key is one character wider than the
previous longest, so prettier re-pads every row of the table — the substantive
change is two rows.