### PR TITLE
fix: validate client resize payload before resizing the PTY

### DIFF
--- a/src/server/spawn.ts
+++ b/src/server/spawn.ts
@@ -3,6 +3,7 @@ import { logger as getLogger } from '../shared/logger.js';
 import { tinybuffer, FlowControlServer } from './flowcontrol.js';
 import { xterm } from './shared/xterm.js';
 import { envVersionOr } from './spawn/env.js';
+import { parseDimensions } from './spawn/resize.js';
 import type SocketIO from 'socket.io';
 
 export async function spawn(
@@ -35,8 +36,19 @@ export async function spawn(
     }
   });
   socket
-    .on('resize', ({ cols, rows }: { cols: number; rows: number }) => {
-      term.resize(cols, rows);
+    .on('resize', (payload: unknown) => {
+      // Socket.IO does not catch throws in listeners, so an invalid size would
+      // otherwise take down the process and every other session with it.
+      const dimensions = parseDimensions(payload);
+      if (dimensions === undefined) {
+        logger.debug('Ignoring invalid resize request', { pid });
+        return;
+      }
+      try {
+        term.resize(dimensions.cols, dimensions.rows);
+      } catch (error) {
+        logger.debug('Resize rejected by PTY', { pid, err: error });
+      }
     })
     .on('input', (input: string) => {
       term.write(input);

--- a/src/server/spawn/resize.spec.ts
+++ b/src/server/spawn/resize.spec.ts
@@ -1,0 +1,56 @@
+import 'mocha';
+import { expect } from 'chai';
+import { parseDimensions } from './resize';
+
+describe('Client supplied terminal dimensions should be validated before resizing the PTY', () => {
+  it('should accept a well formed payload', () => {
+    expect(parseDimensions({ cols: 80, rows: 30 })).to.deep.equal({
+      cols: 80,
+      rows: 30,
+    });
+  });
+
+  it('should ignore extra properties', () => {
+    expect(
+      parseDimensions({ cols: 120, rows: 40, extra: 'ignored' }),
+    ).to.deep.equal({ cols: 120, rows: 40 });
+  });
+
+  it('should reject payloads that are not objects', () => {
+    expect(parseDimensions(undefined)).to.equal(undefined);
+    expect(parseDimensions(null)).to.equal(undefined);
+    expect(parseDimensions('80x30')).to.equal(undefined);
+    expect(parseDimensions(42)).to.equal(undefined);
+  });
+
+  it('should reject missing dimensions', () => {
+    expect(parseDimensions({})).to.equal(undefined);
+    expect(parseDimensions({ cols: 80 })).to.equal(undefined);
+    expect(parseDimensions({ rows: 30 })).to.equal(undefined);
+  });
+
+  it('should reject dimensions node-pty would refuse', () => {
+    expect(parseDimensions({ cols: 0, rows: 30 })).to.equal(undefined);
+    expect(parseDimensions({ cols: 80, rows: 0 })).to.equal(undefined);
+    expect(parseDimensions({ cols: -1, rows: 30 })).to.equal(undefined);
+    expect(parseDimensions({ cols: 80, rows: -1 })).to.equal(undefined);
+  });
+
+  it('should reject non integer and non finite dimensions', () => {
+    expect(parseDimensions({ cols: Number.NaN, rows: 30 })).to.equal(undefined);
+    expect(
+      parseDimensions({ cols: 80, rows: Number.POSITIVE_INFINITY }),
+    ).to.equal(undefined);
+    expect(parseDimensions({ cols: 80.5, rows: 30 })).to.equal(undefined);
+    expect(parseDimensions({ cols: '80', rows: '30' })).to.equal(undefined);
+  });
+
+  it('should reject dimensions above the allowed maximum', () => {
+    expect(parseDimensions({ cols: 10000, rows: 30 })).to.equal(undefined);
+    expect(parseDimensions({ cols: 80, rows: 10000 })).to.equal(undefined);
+    expect(parseDimensions({ cols: 9999, rows: 9999 })).to.deep.equal({
+      cols: 9999,
+      rows: 9999,
+    });
+  });
+});

--- a/src/server/spawn/resize.ts
+++ b/src/server/spawn/resize.ts
@@ -1,0 +1,33 @@
+/**
+ * Upper bound on the terminal size a client may request. Well above any real
+ * display, but low enough that a hostile value cannot be used to make node-pty
+ * allocate an absurd buffer.
+ */
+const maxDimension = 9999;
+
+export interface Dimensions {
+  cols: number;
+  rows: number;
+}
+
+const isPositiveDimension = (value: unknown): value is number =>
+  typeof value === 'number' &&
+  Number.isInteger(value) &&
+  value > 0 &&
+  value <= maxDimension;
+
+/**
+ * Validate a client supplied terminal size.
+ *
+ * The payload arrives straight off the socket, so it may be missing, of the
+ * wrong type, or hold values node-pty rejects. Returns undefined for anything
+ * unusable so the caller can drop the event instead of throwing.
+ */
+export function parseDimensions(payload: unknown): Dimensions | undefined {
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const { cols, rows } = payload as Partial<Dimensions>;
+  if (!isPositiveDimension(cols) || !isPositiveDimension(rows)) {
+    return undefined;
+  }
+  return { cols, rows };
+}


### PR DESCRIPTION
The `resize` Socket.IO handler destructured `{ cols, rows }` from the client payload and passed both straight to `term.resize()`. Socket.IO does not catch exceptions thrown inside listeners, so two trivially reachable inputs became an uncaught exception:

- a non-object payload (`null`, `undefined`, a string) made the destructuring throw a `TypeError`
- missing, zero, negative, fractional or non-finite dimensions made node-pty throw `cols and rows must be positive`

Because one wetty process multiplexes every connected user's PTY, either throw terminated the process and every concurrent terminal session with it — a denial of service any connected client could trigger with a single malformed event.

Add `parseDimensions()`, which returns `undefined` for anything unusable, and drop invalid resize events with a debug log instead of throwing. Keep a `try`/`catch` around `term.resize()` so a rejection from node-pty cannot take the process down either.